### PR TITLE
do not mention pystac, doesn't work

### DIFF
--- a/APIs/STAC.md
+++ b/APIs/STAC.md
@@ -8,7 +8,7 @@ STAC (Spatio-Temporal Asset Catalog) is a relatively new web service specificati
 The version exposed in the Copernicus Dataspace is still subject to change as the quality of STAC metadata is still improving. Nevertheless,
 it already supports basic product search.
 
-There are known issues with using the current version with generic STAC libraries. 
+We are aware of issues with using the current version with generic STAC libraries. The data model in the Copernicus Dataspace Ecosystem is still evolving to comply fully with all standardized properties. Our dedicated teams are actively working on its development to ensure a seamless experience for all our customers. However, as the version exposed in the Copernicus Dataspace is still subject to change as the quality of STAC metadata is still improving, we kindly ask for your patience and understanding.
 
 
 


### PR DESCRIPTION
use of pystac is reported to be broken with current catalog, so this sentence needs to be removed