### PR TITLE
STAC review

### DIFF
--- a/Data/Sentinel1.qmd
+++ b/Data/Sentinel1.qmd
@@ -10,7 +10,7 @@ jupyter: python3
 ```{python}
 #| tags: [parameters]
 
-mission = "Sentinel-1"
+constellation = "Sentinel-1"
 
 ```
 

--- a/Data/Sentinel2.qmd
+++ b/Data/Sentinel2.qmd
@@ -11,7 +11,7 @@ jupyter: python3
 ```{python}
 #| tags: [parameters]
 
-mission = "Sentinel-2"
+constellation = "Sentinel-2"
 
 ```
 The [Copernicus Sentinel-2 mission](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-2){target="_blank"} comprises a land monitoring constellation of two polar-orbiting satellites placed in the same sun-synchronous orbit, phased at 180° to each other. It aims at monitoring variability in land surface conditions, and its wide swath width (290 km) and high revisit time (10 days at the equator with one satellite, and 5 days with 2 satellites which results in 2-3 days at mid-latitudes) will support monitoring of Earth's surface changes.

--- a/Data/Sentinel3.qmd
+++ b/Data/Sentinel3.qmd
@@ -10,7 +10,7 @@ jupyter: python3
 ```{python}
 #| tags: [parameters]
 
-mission = "Sentinel-3"
+constellation = "Sentinel-3"
 
 ```
 

--- a/Data/Sentinel5P.qmd
+++ b/Data/Sentinel5P.qmd
@@ -10,7 +10,7 @@ jupyter: python3
 ```{python}
 #| tags: [parameters]
 
-mission = "Sentinel-5P"
+constellation = "Sentinel-5P"
 
 
 ```

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -12,7 +12,7 @@ meta = None
 with open("./collections.json") as f:
     meta = json.load(f)["collections"]
 
-meta = [ c for c in meta if mission in c["mission"] ]
+meta = [ c for c in meta if constellation in c["constellation"] ]
 
 ```
 

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -297,8 +297,11 @@ for c in meta:
         cite = ""
 
 
-    if license_url is not None:
-        license_button = f"""<a href="{license_url}" target="_blank">{sci_cite}</a>"""
+    if sci_cite is not None:
+        if license_url is not None and  license_url != "":
+            license_button = f"""<a href="{license_url}" target="_blank">{sci_cite}</a>"""
+        else:
+            license_button = f"""{sci_cite}"""
     else:
         license_button = ""
 

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -94,10 +94,10 @@ def togglescript():
 ```{python}
 # include detail block
 
-def detailblock(ID,xy,time,table,link_block,license_button):
+def detailblock(ID,xy,time,table,link_block,license_button,cite):
     
     if any(val for val in (xy, time, table, link_block) if not val.isspace() and val != ""):
-        bandinfo = f"""<button onclick="toggleContent('{ID}')" class="expand-collapse">Further details about the data collection</button><div class="expand-content" id="{ID}" style="display:none;"><div class="row" style="display: flex; justify-content: space-around"><div class="column">{xy}</div><div class="column">{time}</div></div><div>{table}</div><div>{license_button}</div><div>{link_block}</div></div>"""
+        bandinfo = f"""<button onclick="toggleContent('{ID}')" class="expand-collapse">Further details about the data collection</button><div class="expand-content" id="{ID}" style="display:none;"><div class="row" style="display: flex; justify-content: space-around"><div class="column">{license_button}&nbsp;&nbsp;{cite}</div></div><div class="row" style="display: flex; justify-content: space-around"><div class="column">{xy}</div><div class="column">{time}</div></div><div>{table}</div><div>{link_block}</div></div>"""
     else:
         bandinfo = ""
     return bandinfo
@@ -258,6 +258,11 @@ for c in meta:
     except:
         license_type = "" 
 
+    try: 
+        sci_cite = c["sci:citation"]
+    except:
+        sci_cite = ""
+
     # insert thumbnail
     thumb_url = get_thumbnail(c)
 
@@ -277,7 +282,8 @@ for c in meta:
     userguide = find_link(rel="about",title_contains="User")
     opensearch = find_link(rel="opensearch")
     databrowser = find_link(rel="browser",title_contains="Data-Browser")
-    license_url = databrowser = find_link(rel="license")
+    license_url = find_link(rel="license")
+    cite = find_link(rel="cite-as")
     
 
     if userguide is not None:
@@ -285,9 +291,14 @@ for c in meta:
     else:
         userguide = ""
 
+    if cite is not None:
+        cite = f"""[!["Cite"](https://img.shields.io/badge/-Cite-77cc09)]({cite}){{target='_blank'}}"""
+    else:
+        cite = ""
+
 
     if license_url is not None:
-        license_button = f"""<a href="{license_url}" target="_blank"><img src="https://img.shields.io/badge/License-{license_type}-0A4393" /></a>"""
+        license_button = f"""<a href="{license_url}" target="_blank">{sci_cite}</a>"""
     else:
         license_button = ""
 
@@ -333,7 +344,7 @@ for c in meta:
 {offer}
 
 
-{detailblock(collectionID,spatial,temporal,table,link_block,license_button )}
+{detailblock(collectionID,spatial,temporal,table,link_block,license_button,cite )}
 
 
 """

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -45,9 +45,13 @@ def thumbblock(src,userguide, opensearch, gsd,revisit_time, datatype):
 def necessary_links(c):
     stac = get_stac(c)
     wmts = get_wmts()
-    if stac:
+    if stac and wmts:
         link_block =f"""<h5>Useful Links</h5><li>{stac}</li><li>{wmts}</li>"""
-    else:
+    elif stac:
+        link_block =f"""<h5>Useful Links</h5><li>{stac}</li>"""
+    elif wmts:
+        link_block =f"""<h5>Useful Links</h5><li>{wmts}</li>"""
+    else:    
         link_block = ""
     return link_block
 ```

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -94,10 +94,10 @@ def togglescript():
 ```{python}
 # include detail block
 
-def detailblock(ID,xy,time,table,link_block):
+def detailblock(ID,xy,time,table,link_block,license_button):
     
     if any(val for val in (xy, time, table, link_block) if not val.isspace() and val != ""):
-        bandinfo = f"""<button onclick="toggleContent('{ID}')" class="expand-collapse">Further details about the data collection</button><div class="expand-content" id="{ID}" style="display:none;"><div class="row" style="display: flex; justify-content: space-around"><div class="column">{xy}</div><div class="column">{time}</div></div><div>{table}</div><div>{link_block}</div></div>"""
+        bandinfo = f"""<button onclick="toggleContent('{ID}')" class="expand-collapse">Further details about the data collection</button><div class="expand-content" id="{ID}" style="display:none;"><div class="row" style="display: flex; justify-content: space-around"><div class="column">{xy}</div><div class="column">{time}</div></div><div>{table}</div><div>{license_button}</div><div>{link_block}</div></div>"""
     else:
         bandinfo = ""
     return bandinfo
@@ -218,6 +218,7 @@ def get_availablity(c):
     return table
 ```
 
+
 ```{python}
 # for loop to display the content
 text = ''
@@ -252,6 +253,11 @@ for c in meta:
         LevelID = ""
         About = ""
 
+    try:
+        license_type = c["license"]
+    except:
+        license_type = "" 
+
     # insert thumbnail
     thumb_url = get_thumbnail(c)
 
@@ -271,11 +277,19 @@ for c in meta:
     userguide = find_link(rel="about",title_contains="User")
     opensearch = find_link(rel="opensearch")
     databrowser = find_link(rel="browser",title_contains="Data-Browser")
+    license_url = databrowser = find_link(rel="license")
+    
 
     if userguide is not None:
         userguide = f"""[![User guide](https://img.shields.io/badge/-User_guide-77cc09)]({userguide}){{target='_blank'}}"""
     else:
         userguide = ""
+
+
+    if license_url is not None:
+        license_button = f"""<a href="{license_url}" target="_blank"><img src="https://img.shields.io/badge/License-{license_type}-0A4393" /></a>"""
+    else:
+        license_button = ""
 
 
     if databrowser is not None:
@@ -318,7 +332,8 @@ for c in meta:
 
 {offer}
 
-{detailblock(collectionID,spatial,temporal,table,link_block)}
+
+{detailblock(collectionID,spatial,temporal,table,link_block,license_button )}
 
 
 """

--- a/Data/_render_collections.qmd
+++ b/Data/_render_collections.qmd
@@ -134,36 +134,66 @@ def get_extent(c):
 ```
 
 ```{python}
+from tabulate import tabulate
+
 def get_bandtable(c):
     tabletitle = "Spectral Bands"
-    try: 
+    try:
         band_num = len(c['summaries']['eo:bands'])
         t = []
-        for i in range(0,band_num):
+        headers = ["Band Name", "Common Name", "GSD(m)", "Center Wavelength(μm)"]
+        empty_columns = [True] * len(headers)  # Track empty columns
+        
+        for i in range(band_num):
+            band_data = c['summaries']['eo:bands'][i]
+            
             try:
-                band = c['summaries']['eo:bands'][i]['name'] 
+                band = band_data['name']
             except:
                 band = ""
+            
             try:
-                c_name = c['summaries']['eo:bands'][i]['common_name']
+                c_name = band_data['common_name']
             except:
                 c_name = ''
+            
             try:
-                b_gsd = c['summaries']['eo:bands'][i]['gsd']
+                b_gsd = band_data['gsd']
             except:
                 b_gsd = ''
+            
             try:
-                b_wavelength = c['summaries']['eo:bands'][i]['center_wavelength']
+                b_wavelength = band_data['center_wavelength']
             except:
                 b_wavelength = ''
-            t.append([band,c_name,b_gsd,b_wavelength])
-        table = tabulate(t,headers=["Band Name", "Common Name", "GSD(m)", "Center Wavelength(μm)"], tablefmt='html', floatfmt=".4f",stralign="center",numalign="center")
-        # Set the minimum width of each column to 100 pixels
-        table = table.replace("<table>", '<table class="table">')
-        table = f"""<h5>{tabletitle}</h5>{table}"""
+            
+            row = [band, c_name, b_gsd, b_wavelength]
+            t.append(row)
+            
+            # Check for empty columns
+            for j, value in enumerate(row):
+                if value:
+                    empty_columns[j] = False
+        
+        # Remove empty columns from headers and table rows
+        headers = [header for i, header in enumerate(headers) if not empty_columns[i]]
+        t = [[row[i] for i, value in enumerate(row) if not empty_columns[i]] for row in t]
+        
+        # Check if all columns are empty
+        if len(headers) == 0:
+            table = ""
+        else:
+            table = tabulate(t, headers=headers, tablefmt='html', floatfmt=".4f", stralign="center", numalign="center")
+            # Set the minimum width of each column to 100 pixels
+            table = table.replace("<table>", '<table class="table">')
+            table = f"""<h5>{tabletitle}</h5>{table}"""
     except:
-        table = " "
+        table = ""
+    
     return table
+
+
+
 ```
 
 ```{python}

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -4,7 +4,7 @@
             "id": "SENTINEL1_GRD",
             "title": "Sentinel-1 Level 1 Ground Range Detected (GRD)",
             "description": "The [Sentinel 1 Level 1 GRD](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-1){target='_blank'} products in this Collection consist of focused SAR data that has been detected, multi-looked and projected to ground range using the Earth ellipsoid model WGS84. The ellipsoid projection of the GRD products is corrected using the terrain height specified in the product general annotation. The terrain height used varies in azimuth but is constant in range (but can be different for each IW/EW sub-swath). Ground range coordinates are the slant range coordinates projected onto the ellipsoid of the Earth. Pixel values represent detected amplitude. Phase information is lost. The resulting product has approximately square resolution pixels and square pixel spacing with reduced speckle at a cost of reduced spatial resolution.",
-            "mission": "Sentinel-1",
+            "constellation": "Sentinel-1",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -192,7 +192,7 @@
             "id": "SENTINEL1_SLC",
             "title": "Sentinel-1 Level 1 Single Look Complex (SLC)",
             "description": "The [Sentinel 1 Level 1 SLC](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1-algorithms/single-look-complex){target='_blank'}  products are images in the slant range by azimuth imaging plane, in the image plane of satellite data acquisition. Each image pixel is represented by a complex (I and Q) magnitude value and therefore contains both amplitude and phase information. Each I and Q value is 16 bits per pixel. The processing for all SLC products results in a single look in each dimension using the full available signal bandwidth. The imagery is geo-referenced using orbit and attitude data from the satellite. ",
-            "mission": "Sentinel-1",
+            "constellation": "Sentinel-1",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -267,7 +267,7 @@
             "id": "SENTINEL1_OCN",
             "title": "Sentinel-1 Level 2 Ocean (OCN)",
             "description": "The [Sentinel-1 Level 2 OCN (Ocean)](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-2){target='_blank'} products are specifically processed radar data products for oceanographic applications. These products are derived from Sentinel-1 SAR data. They are tailored to meet the needs of oceanographic studies, such as monitoring sea surface conditions, detecting oil spills, tracking marine vessels, and studying ocean currents. The OCN products typically involve specialized processing techniques to extract relevant oceanographic information from the radar data. This can include surface wave analysis, wind speed and direction estimation, ocean surface current mapping, and identifying features such as oil slicks or marine traffic.",
-            "mission": "Sentinel-1",
+            "constellation": "Sentinel-1",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -338,7 +338,7 @@
             "id": "SENTINEL1_L0",
             "title": "Sentinel-1 Level 0",
             "description": "The [Sentinel-1 Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-0){target='_blank'} products are unprocessed radar measurements obtained by the satellite's SAR system, containing amplitude and phase information. They serve as the initial input for generating higher-level radar products with calibrated and corrected data.",
-            "mission": "Sentinel-1",
+            "constellation": "Sentinel-1",
             "LevelID":"Level-0",
             "keywords": [
                 "raster",
@@ -405,7 +405,6 @@
             "id": "SENTINEL2_L2A",
             "title": "Sentinel-2 Level 2A Top of Canopy (TOC)",
             "description": "[Sentinel-2 Level 2A](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-2a){target='_blank'} Level 2A product provides atmospherically corrected Surface Reflectance (SR) images, derived from the associated Level-1C products. The atmospheric correction of Sentinel-2 images includes the correction of the scattering of air molecules (Rayleigh scattering), of the absorbing and scattering effects of atmospheric gases, in particular ozone, oxygen and water vapour and the correction of absorption and scattering due to aerosol particles. Level 2A product are considered an ARD product.",
-            "mission": "Sentinel-2",
             "constellation": "sentinel-2",
             "sci:citation": "Copernicus Sentinel data 2023",
             "sci:doi": "10.5270/S2_-znk9xsj",
@@ -648,7 +647,7 @@
             "id": "SENTINEL2_L1C",
             "title": "Sentinel-2 Level 1C Top of Atmosphere (TOA)",
             "description": "[Sentinel-2 Level 1C](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1c){target='_blank'} products are available globally from 2015 onwards. These products are resampled with a constant Ground Sampling Distance (GSD) of 10, 20 and 60 m, depending on the native resolution of the different spectral bands. Pixel coordinates refer to the upper left corner of the pixel. ",
-            "mission": "Sentinel-2",
+            "constellation": "Sentinel-2",
             "constellation": "sentinel-2",
             "gsd": 10,
             "revisit":5,
@@ -859,7 +858,7 @@
             "id": "SENTINEL2_L1B",
             "title": "Sentinel-2 Level 1B",
             "description": "The [Sentinel-2 Level 1B](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1b){target='_blank'} product provides radiometrically corrected imagery in Top-Of-Atmosphere (TOA) radiance values and in sensor geometry. Additionally, this product includes the refined geometric model which is used to generate the Level 1C product.",
-            "mission": "Sentinel-2",
+            "constellation": "Sentinel-2",
             "LevelID":"Level-1",
             "type": "Unprojected",
             "links": [
@@ -898,7 +897,7 @@
             "id": "SENTINEL2_L0",
             "title": "Sentinel-2 Level 0",
             "description": "Sentinel-2 Level-0 data is the raw data acquired by the Sentinel-2 satellite before any processing or calibration is applied. The purpose of Sentinel-2 Level-0 data is to provide a baseline for further processing and analysis of the images. Before the data can be used for scientific or operational applications, it must be preprocessed to correct for geometric distortions, radiometric calibration, atmospheric corrections, and other factors that can affect the accuracy and quality of the data.",
-            "mission": "Sentinel-2",
+            "constellation": "Sentinel-2",
             "LevelID":"Level-0",
             "type": "Unprojected",
             "links": [
@@ -930,7 +929,7 @@
             "id": "SENTINEL3_OLCI_L1",
             "title": "Sentinel-3 OLCI Level 1",
             "description": "The [Sentinel-3 OLCI Level 1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-1){target='_blank'} products provides calibrated, geolocated, and orthorectified data from the Ocean and Land Colour Instrument (OLCI). These products are delivered not later than 1 month (commitment) after acquisition or from long-term archives. ",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-1",
             "gsd":300,
             "assets": {
@@ -1142,7 +1141,7 @@
             "id": "SENTINEL3_OLCI_L2",
             "title": "Sentinel-3 OLCI Level 2",
             "description": "The [Sentinel-3 OLCI Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-2){target='_blank'} product provides geophysical data that is derived from the Level-1 product. These products contains retrieved geophysical parameters, such as chlorophyll-a concentration, total suspended matter, and inherent optical properties of water.The Level-2 product also includes data quality flags that provide information on the reliability of the geophysical parameters, as well as information on the atmospheric correction applied to the data. These flags can be used to filter out data that is not of sufficient quality for a particular application.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-2",
             "gsd":300,
             "extent": {
@@ -1203,7 +1202,7 @@
             "id": "SENTINEL3_OLCI_L0",
             "title": "Sentinel-3 OLCI Level 0",
             "description": "The [Sentinel-3 OLCI Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-0){target='_blank'}  is the reconstructed and time-sorted Instrument Source Packet (ISP) at full space-time resolution. The first part of the process involves unpacking the ISPs, performing a quality check and appending annotation data to them. Once the input raw data files are read, all necessary data are extracted and parsed. The ISPs are then sorted and checked, including missing and duplicated packet numbering. The final part of the processing is the Level-0 product generation. Several quality flags are computed and included in the associated metadata. Raw data, time sorted and annotated are included in the Level-0 package.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-0",
             "gsd":300,
             "extent": {
@@ -1370,7 +1369,7 @@
             "id": "SENTINEL3_SLSTR_L1",
             "title": "Sentinel-3 SLSTR Level 1",
             "description": "The [Sentinel-3 SLSTR Level-1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-1){target='_blank'} product provides a valuable source of processed and calibrated data that is suitable for a wide range of applications. The product includes key parameters and data quality flags that provide important information on the reliability and accuracy of the data, and the product is generated offline with a delay of a few days after the acquisition of the Level-0 data.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -1538,7 +1537,7 @@
             "id": "SENTINEL3_SLSTR_L2",
             "title": "Sentinel-3 SLSTR Level 2",
             "description": "The [Sentinel-3 SLSTR Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-2){targte='_blank'} product provides higher-level geophysical parameters, but with a longer processing time and coarser spatial resolution compared to the Level-1 product. The product also includes additional data quality flags to provide more information on the reliability and accuracy of the data.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -1592,7 +1591,7 @@
             "id": "SENTINEL3_SLSTR_L0",
             "title": "Sentinel-3 SLSTR Level 0",
             "description": "The [Sentinel-3 SLSTR Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-0){target='_blank'} product is the raw unprocessed data acquired by the SLSTR instrument on board the Sentinel-3 satellite. It consists of the uncalibrated digital counts received by the SLSTR detectors for each pixel in the image. It provides a valuable source of unprocessed data for researchers and advanced users who require access to the raw data for their applications. ",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-0",
             "gsd":500,
             "extent": {
@@ -1696,7 +1695,7 @@
             "id": "SENTINEL3_SYN_L2",
             "title": "Sentinel-3 SYN Level 2",
             "description": "The [Sentinel-3 SYN Level 2 ](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-3/data-products/synergy){target='blank'} product is a higher-level processed product that contains information about the Earth's atmosphere and its constituents.  It is derived from the Level-1 and Level-2 products of the OLCI and SLSTR instruments on board the Sentinel-3 satellite.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -1758,7 +1757,7 @@
             "id": "SENTINEL3_SRAL_L1",
             "title": "Sentinel-3 SRAL Level 1",
             "description": "The [Sentinel-3 SRAL Level-1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-1){target='blank'} product provides corrected and validated geophysical parameters derived from the raw SRAL Level-0 data, along with metadata and data quality flags that enable the user to assess the reliability and suitability of the data for specific applications.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-1",
             "extent": {
                 "spatial": {
@@ -1820,7 +1819,7 @@
             "id": "SENTINEL3_SRAL_L2",
             "title": "Sentinel-3 SRAL Level 2",
             "description": "The [Sentinel-3 SRAL Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-2){target='blank'} product is a higher-level processed product that contains more detailed and refined geophysical parameters suitable for scientific and research applications. It contains advanced geophysical parameters such as sea surface height, significant wave height, and wind speed, that are derived from the SRAL Level-1 products using advanced processing algorithms and quality control procedures.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -1882,7 +1881,7 @@
             "id": "SENTINEL3_SRAL_L0",
             "title": "Sentinel-3 SRAL Level 0",
             "description": "The [Sentinel-3 Synthetic Aperture Radar Altimeter (SRAL) Level-0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-0){target='_blank'} product contains raw data acquired by the SRAL instrument onboard the Sentinel-3 satellite. The data contains raw, time-tagged radar echoes and instrument housekeeping data, along with metadata describing the acquisition parameters and instrument characteristics.",
-            "mission": "Sentinel-3",
+            "constellation": "Sentinel-3",
             "LevelID":"Level-0",
             "extent": {
                 "spatial": {
@@ -1927,7 +1926,7 @@
             "id": "SENTINEL5P_L2_AER_AI",
             "title": "Sentinel-5P Level 2 Aerosol Index",
             "description": "The [Sentinel-5P Level 2 Aerosol Index (AER_AI)](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-uv-aerosol-index-atbd?){target='_blank'} dataset provides high-resolution imagery of the UV Aerosol Index (UVAI), also called the Absorbing Aerosol Index (AAI). The AAI is based on wavelength-dependent changes in Rayleigh scattering in the UV spectral range for a pair of wavelengths. The difference between observed and modelled reflectance results in the AAI. When the AAI is positive, it indicates the presence of UV-absorbing aerosols like dust and smoke. It is useful for tracking the evolution of episodic aerosol plumes from dust outbreaks, volcanic ash, and biomass burning.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2010,7 +2009,7 @@
             "id": "SENTINEL5P_L2_CO",
             "title": "Sentinel-5P Level 2 Carbon Monoxide",
             "description": "The [Sentinel-5P Level 2 CO](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-carbon-monoxide-level-2-product-readme-file?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission, specifically focusing on measuring and analyzing the concentration of carbon monoxide in the Earth's atmosphere. It includes data on the total column carbon monoxide content, as well as vertical profiles that describe how the concentration changes with altitude.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2079,7 +2078,7 @@
             "id": "SENTINEL5P_L2_CLOUD",
             "title": "Sentinel-5P Level 2 Cloud",
             "description": "The [Sentinel-5P Level 2 Cloud](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-cloud-products-atbd?){target='_blank'} dataset provides high-resolution imagery of cloud parameters. The TROPOMI/S5P cloud properties retrieval is based on the OCRA and ROCINN algorithms currently being used in the operational GOME and GOME-2 products. OCRA retrieves the cloud fraction using measurements in the UV/VIS spectral regions and ROCINN retrieves the cloud height (pressure) and optical thickness (albedo) using measurements in and around the oxygen A-band at 760 nm. Additionally, the cloud parameters are also provided for a cloud model which assumes the cloud to be a Lambertian reflecting boundary.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2158,7 +2157,7 @@
             "id": "SENTINEL5P_L2_HCHO",
             "title": "Sentinel-5P Level 2 Formaldehyde",
             "description": "The [Sentinel-5P Level 2 HCHO](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-formaldehyde-level-2-readme?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focus on measuring and analyzing the concentration of formaldehyde in the Earth's atmosphere. The Level 2 Formaldehyde data also incorporates auxiliary information, such as geolocation, cloud properties, and surface reflectance, which are crucial for contextualizing and interpreting the measurements.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2241,7 +2240,7 @@
             "id": "SENTINEL5P_L2_CH4",
             "title": "Sentinel-5P Level 2 Methane",
             "description": "The [Sentinel-5P Level 2 CH4](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-methane-product-readme-file?){target='_blank'} data from the Copernicus Sentinel-5P satellite shows the methane concentrations globally. This product provides processed and derived measurements of methane concentrations in the Earth's atmosphere. It is a valuable resource for studying climate change, understanding methane emissions, and informing environmental policies and mitigation efforts.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2310,7 +2309,7 @@
             "id": "SENTINEL5P_L2_NO2",
             "title": "Sentinel-5P Level 2 Nitrogen Dioxide",
             "description": "The [Sentinel-5P Level 2 NO2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-level-2-product-user-manual-nitrogen-dioxide?){target='_blank'} data comes from the Copernicus Sentinel-5P satellite and shows the nitrogen dioxide concentrations across the globe. Concentrations of short-lived pollutants, such as nitrogen dioxide, are indicators of changes in economic slowdowns and are comparable to changes in emissions.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2385,7 +2384,7 @@
             "id": "SENTINEL5P_L2_O3",
             "title": "Sentinel-5P Level 2 Ozone",
             "description": "The [Sentinel-5P Level 2 O3](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-ozone-profile-product-readme-file?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focuses on measuring and analyzing the concentration and distribution of ozone in the Earth's atmosphere. Researchers and scientists utilize this data for various purposes, that includes monitoring and assessing ozone depletion, particularly in regions like the polar areas, where the ozone layer is crucial. Additionally, the data aids in air quality monitoring, enabling the evaluation of ozone pollution control measures and understanding of pollution sources. ",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2465,7 +2464,7 @@
             "id": "SENTINEL5P_L2_SO2",
             "title": "Sentinel-5P Level 2 Sulfur Dioxide",
             "description": "The [Sentinel-5P Level 2 SO2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-sulphur-dioxide-level-2-readme?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focuses on measuring and analyzing the concentration and distribution of sulfur dioxide in the Earth's atmosphere. It provides comprehensive information on atmospheric sulfur dioxide's vertical distribution and spatial variations. It includes data on the total column sulfur dioxide content and vertical profiles that describe how the concentration changes with altitude. This data also incorporates auxiliary information, such as geolocation, cloud properties, and surface reflectance, which are crucial for contextualising and interpreting the measurements.  It is a valuable resource for studying air quality, volcanic activity, atmospheric chemistry, and assessing the impacts of sulfur dioxide on human health and the environment.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2548,7 +2547,7 @@
             "id": "SENTINEL5P_L1B",
             "title": "Sentinel-5P Level 1B",
             "description": "The [Sentinel-5P Level 1B](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-5p/products-algorithms/level-1b){target='_blank'} data refers to a processed and calibrated dataset derived from the raw measurements acquired by the Sentinel-5P satellite. This level of data undergoes initial processing steps to correct for instrument effects, atmospheric disturbances, and other artifacts. ",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-1",
             "links": [
                 {
@@ -2578,7 +2577,7 @@
             "id": "SENTINEL5P_L0",
             "title": "Sentinel-5P Level 0",
             "description": "The [Sentinel-5P Level 0](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-5p/products-algorithms/level-0){target='_blank'} data refers to the raw data acquired by the Sentinel-5P satellite during its mission. These instruments include the Tropospheric Monitoring Instrument (TROPOMI), which is capable of measuring a wide range of atmospheric pollutants such as nitrogen dioxide, ozone, formaldehyde, and aerosols, among others.",
-            "mission": "Sentinel-5P",
+            "constellation": "Sentinel-5P",
             "LevelID":"Level-0",
             "keywords": [
                 "aai",

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -417,7 +417,7 @@
             "id": "SENTINEL2_L2A",
             "title": "Sentinel-2 Level 2A Top of Canopy (TOC)",
             "description": "[Sentinel-2 Level 2A](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-2a){target='_blank'} Level 2A product provides atmospherically corrected Surface Reflectance (SR) images, derived from the associated Level-1C products. The atmospheric correction of Sentinel-2 images includes the correction of the scattering of air molecules (Rayleigh scattering), of the absorbing and scattering effects of atmospheric gases, in particular ozone, oxygen and water vapour and the correction of absorption and scattering due to aerosol particles. Level 2A product are considered an ARD product.",
-            "constellation": "sentinel-2",
+            "constellation": "Sentinel-2",
             "sci:citation": "Copernicus Sentinel data 2023",
             "sci:doi": "10.5270/S2_-znk9xsj",
             "gsd": 10,

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -27,14 +27,10 @@
                         ]
                 },
                 "temporal": {
-                    "interval": [
-                            "Oct 2014 - Present"
-                    ]
+                    "interval": ["2014-10-03T00:00:00Z",null]
                 }
             },
             "keywords": [
-                "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "satellite imagery",
@@ -46,9 +42,7 @@
                 "maritime monitoring",
                 "land monitoring",
                 "disaster response",
-                "open data",
-                "race challenges",
-                "sentinel"
+                "open data"
             ],
             "links": [
                 {
@@ -61,10 +55,6 @@
                     "rel": "opensearch"
                 },
                 {
-                    "href": "https://collections.eurodatacube.com/stac/sentinel-1-grd.json",
-                    "rel": "self"
-                },
-                {
                     "href": "https://services.sentinel-hub.com/ogc/wmts/113184fa-263a-4bd8-a2d3-0c00fbcef8b5",
                     "rel": "wmts",
                     "wmts:dimensions": {
@@ -74,6 +64,84 @@
                 }
             ],
             "summaries": {
+                 "platform": [
+                  "sentinel-1a",
+                  "sentinel-1b"
+                ],
+                "instrument": [
+                  "c-sar"
+                ],
+                "constellation": [
+                  "sentinel-1"
+                ],
+                "sat:orbit_state": [
+                  "ascending",
+                  "descending"
+                ],
+                "sar:instrument_mode": [
+                  "SM",
+                  "IW",
+                  "EW",
+                  "WV"
+                ],
+                "sar:frequency_band": [
+                  "C"
+                ],
+                "sar:center_frequency": [
+                  5.405
+                ],
+                "sar:product_type": [
+                  "GRD"
+                ],
+                "sar:polarizations": [
+                  "HH",
+                  "HV",
+                  "VH",
+                  "VV"
+                ],
+                "sar:resolution_range": [
+                  9,
+                  20,
+                  23,
+                  50,
+                  52,
+                  84,
+                  88,
+                  93
+                ],
+                "sar:resolution_azimuth": [
+                  9,
+                  22,
+                  23,
+                  50,
+                  51,
+                  84,
+                  87
+                ],
+                "sar:pixel_spacing_range": [
+                  3.5,
+                  10,
+                  25,
+                  40
+                ],
+                "sar:pixel_spacing_azimuth": [
+                  3.5,
+                  10,
+                  25,
+                  40
+                ],
+                  "eo:bands": [
+                    {
+                      "name": "VH",
+                      "type": "float",
+                      "unit": "1"
+                    },
+                    {
+                      "name": "VV",
+                      "type": "float",
+                      "unit": "1"
+                    }
+                  ],
                 "DataAvailability":
                 [
                     {
@@ -137,8 +205,6 @@
                 }
             },
             "keywords": [
-                "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "satellite imagery",
@@ -151,8 +217,7 @@
                 "land monitoring",
                 "disaster response",
                 "open data",
-                "race challenges",
-                "sentinel"
+                "race challenges"
             ],
             "links": [
                 {
@@ -221,8 +286,6 @@
                 }
             },
             "keywords": [
-                "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "satellite imagery",
@@ -235,7 +298,6 @@
                 "land monitoring",
                 "disaster response",
                 "open data",
-                "race challenges",
                 "sentinel"
             ],
             "links": [
@@ -246,7 +308,8 @@
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel1/search.json?&filter=producttype:OCN",
-                    "rel": "opensearch"
+                    "rel": "opensearch",
+                    "title": "Opensearch catalog product query"
                 }
             ],
             "summaries": {
@@ -278,8 +341,6 @@
             "mission": "Sentinel-1",
             "LevelID":"Level-0",
             "keywords": [
-                "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "satellite imagery",
@@ -292,7 +353,6 @@
                 "land monitoring",
                 "disaster response",
                 "open data",
-                "race challenges",
                 "sentinel"
             ],
             "links": [
@@ -346,6 +406,7 @@
             "title": "Sentinel-2 Level 2A Top of Canopy (TOC)",
             "description": "[Sentinel-2 Level 2A](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-2a){target='_blank'} Level 2A product provides atmospherically corrected Surface Reflectance (SR) images, derived from the associated Level-1C products. The atmospheric correction of Sentinel-2 images includes the correction of the scattering of air molecules (Rayleigh scattering), of the absorbing and scattering effects of atmospheric gases, in particular ozone, oxygen and water vapour and the correction of absorption and scattering due to aerosol particles. Level 2A product are considered an ARD product.",
             "mission": "Sentinel-2",
+            "constellation": "sentinel-2",
             "gsd": 10,
             "revisit":5,
             "type": "ARD",
@@ -371,13 +432,11 @@
                 },
                 "temporal": {
                     "interval": [
-                            "July 2015 - Present"
+                            "2015-07-04", null
                     ]
                 }
             },
             "keywords": [
-                "VITO",
-                "TERRASCOPE",
                 "COPERNICUS",
                 "ESA",
                 "Orthoimagery",
@@ -389,6 +448,11 @@
                 "TOC"
             ],
             "links": [
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
+                },
                 {
                     "href": "https://dataspace.copernicus.eu/browser/?zoom=11&lat=45.36638&lng=12.49832&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fsh.dataspace.copernicus.eu%2Fogc%2Fwms%2F28b654e7-8912-4e59-9e58-85b58d768b3a&datasetId=S2_L2A_CDAS&fromTime=2023-02-07T00%3A00%3A00.000Z&toTime=2023-02-07T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR&demSource3D=%22MAPZEN%22&cloudCoverage=10",
                     "title": "CDSE Data-Browser",
@@ -579,6 +643,7 @@
             "title": "Sentinel-2 Level 1C Top of Atmosphere (TOA)",
             "description": "[Sentinel-2 Level 1C](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1c){target='_blank'} products are available globally from 2015 onwards. These products are resampled with a constant Ground Sampling Distance (GSD) of 10, 20 and 60 m, depending on the native resolution of the different spectral bands. Pixel coordinates refer to the upper left corner of the pixel. ",
             "mission": "Sentinel-2",
+            "constellation": "sentinel-2",
             "gsd": 10,
             "revisit":5,
             "LevelID":"Level-1",
@@ -604,13 +669,11 @@
                 },
                 "temporal": {
                     "interval": [
-                            "July 2015 - Present"
+                            "2015-07-04T00:00:00Z",null
                     ]
                 }
             },
             "keywords": [
-                "VITO",
-                "TERRASCOPE",
                 "COPERNICUS",
                 "ESA",
                 "Orthoimagery",
@@ -890,8 +953,6 @@
                 }
             },
             "keywords": [
-                "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "satellite imagery",
@@ -900,9 +961,8 @@
                 "atmospheric aerosols",
                 "marine biology",
                 "maritime monitoring",
-                "OTCI",
+                "OLCI",
                 "open data",
-                "race challenges",
                 "copernicus",
                 "sentinel"
             ],

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -204,6 +204,20 @@
                     "type": "image/jpeg"
                 }
             },
+            "extent": {
+                "spatial": {
+                    "bbox": 
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                },
+                "temporal": {
+                    "interval": ["2014-10-03T00:00:00Z",null]
+                }
+            },
             "keywords": [
                 "raster",
                 "systematic",
@@ -280,9 +294,7 @@
                         ]
                 },
                 "temporal": {
-                    "interval": [
-                            "Oct 2014 - Present"
-                    ]
+                    "interval": ["2014-10-03T00:00:00Z",null]
                 }
             },
             "keywords": [
@@ -648,7 +660,6 @@
             "title": "Sentinel-2 Level 1C Top of Atmosphere (TOA)",
             "description": "[Sentinel-2 Level 1C](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1c){target='_blank'} products are available globally from 2015 onwards. These products are resampled with a constant Ground Sampling Distance (GSD) of 10, 20 and 60 m, depending on the native resolution of the different spectral bands. Pixel coordinates refer to the upper left corner of the pixel. ",
             "constellation": "Sentinel-2",
-            "constellation": "sentinel-2",
             "gsd": 10,
             "revisit":5,
             "LevelID":"Level-1",
@@ -953,7 +964,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1155,7 +1166,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1216,7 +1227,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Feb 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1392,7 +1403,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1550,7 +1561,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1605,7 +1616,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Feb 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1708,7 +1719,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1770,7 +1781,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1832,7 +1843,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Mar 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1894,7 +1905,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Feb 2016 - Present"
+                            "2016-04-17T11:33:13Z",null
                     ]
                 }
             },
@@ -1949,7 +1960,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Jul 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2032,7 +2043,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2100,7 +2111,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2179,7 +2190,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2263,7 +2274,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2332,7 +2343,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2406,7 +2417,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },
@@ -2486,7 +2497,7 @@
                 },
                 "temporal": {
                     "interval": [
-                            "Apr 2018 - Present"
+                            "2018-07-10T11:17:44Z",null
                     ]
                 }
             },

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -63,6 +63,7 @@
                     "wmts:layer": "SAR-URBAN"
                 }
             ],
+            "license": "various",
             "summaries": {
                  "platform": [
                   "sentinel-1a",
@@ -240,10 +241,16 @@
                     "rel": "about"
                 },
                 {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
+                },
+                {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel1/search.json?&filter=producttype:SLC",
                     "rel": "opensearch"
                 }
             ],
+            "license":"proprietary",
             "summaries": {
                 "DataAvailability":
                 [
@@ -460,6 +467,7 @@
                 "Plant Resource",
                 "TOC"
             ],
+            "license":"proprietary",
             "links": [
                 {
                     "rel":"cite-as",
@@ -483,6 +491,11 @@
                     "href": "https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-2-msi/product-types/level-2a",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://services.sentinel-hub.com/ogc/wmts/7d34803f-511c-4caf-9438-6d72f32c8174",
@@ -700,6 +713,7 @@
                 "Plant Resource",
                 "TOC"
             ],
+            "license":"various",
             "links": [
                 {
                     "href": "https://dataspace.copernicus.eu/browser/?zoom=11&lat=45.36638&lng=12.49832&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fsh.dataspace.copernicus.eu%2Fogc%2Fwms%2Fa1343b61-3f53-4c92-b65c-0b432b3e7af6&datasetId=S2_L1C_CDAS&fromTime=2023-05-05T00%3A00%3A00.000Z&toTime=2023-05-05T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR&demSource3D=%22MAPZEN%22&cloudCoverage=10",
@@ -982,6 +996,7 @@
                 "copernicus",
                 "sentinel"
             ],
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://dataspace.copernicus.eu/browser/?zoom=9&lat=43.17231&lng=-3.52163&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fsh.dataspace.copernicus.eu%2Fogc%2Fwms%2F82f84fab-9b1c-4322-beeb-207b0f05afef&datasetId=S3OLCI_CDAS&fromTime=2023-05-16T00%3A00%3A00.000Z&toTime=2023-05-16T23%3A59%3A59.999Z&layerId=1_TRUE_COLOR&demSource3D=%22MAPZEN%22&cloudCoverage=30",
@@ -996,6 +1011,11 @@
                     "href": "https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-1",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://creodias.sentinel-hub.com/ogc/wmts/b486fc4b-9c05-49f0-8360-a31df5c691c0",
@@ -1170,10 +1190,16 @@
                     ]
                 }
             },
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
                     "rel": "opensearch"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-2",
@@ -1423,6 +1449,7 @@
                 "copernicus",
                 "sentinel"
             ],
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://dataspace.copernicus.eu/browser/?zoom=7&lat=45.17203&lng=-1.4131&themeId=DEFAULT-THEME&visualizationUrl=https%3A%2F%2Fsh.dataspace.copernicus.eu%2Fogc%2Fwms%2F786d8259-f04e-41cb-92fa-42f66a890ff9&datasetId=S3SLSTR_CDAS&fromTime=2023-05-16T00%3A00%3A00.000Z&toTime=2023-05-16T23%3A59%3A59.999Z&layerId=F1_VISUALIZED&demSource3D=%22MAPZEN%22&cloudCoverage=30",
@@ -1437,6 +1464,11 @@
                     "href": "https://collections.eurodatacube.com/sentinel-3-l1b-slstr",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://creodias.sentinel-hub.com/ogc/wmts/cf579fd9-135d-4597-b7dc-72e67bb5cf13",
@@ -1565,10 +1597,16 @@
                     ]
                 }
             },
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
                     "rel": "opensearch"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-2",
@@ -1978,6 +2016,7 @@
                 "tropomi",
                 "uvai"
             ],
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://sentinelshare.page.link/DmLr ",
@@ -1988,6 +2027,11 @@
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-ultraviolet-aerosol-index",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__AER_AI%20AND%20processingmode:Offline",
@@ -2126,11 +2170,17 @@
                 "sentinel",
                 "tropomi"
             ],
+            "license":"proprietary",
             "links": [
                 {
                     "href": "https://sentinelshare.page.link/mtKW  ",
                     "title": "CDSE Data-Browser",
                     "rel": "browser"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-CLOUD",
@@ -2205,6 +2255,11 @@
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-formaldehyde",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__HCHO__%20AND%20processingmode:Offline",
@@ -2526,6 +2581,11 @@
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-sulphur-dioxide",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
+                    "type": "application/pdf"
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__SO2___%20AND%20processingmode:Offline",

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -711,7 +711,7 @@
                 "Level-2A",
                 "Radiometry",
                 "Plant Resource",
-                "TOC"
+                "TOA"
             ],
             "license":"various",
             "links": [
@@ -886,6 +886,12 @@
             "constellation": "Sentinel-2",
             "LevelID":"Level-1",
             "type": "Unprojected",
+            "keywords": [
+                "COPERNICUS",
+                "ESA",
+                "Orthoimagery",
+                "Sentinel-2"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&productType=S2MSI2A&startDate=2022-06-11&completionDate=2022-06-22&maxRecords=10",
@@ -925,6 +931,12 @@
             "constellation": "Sentinel-2",
             "LevelID":"Level-0",
             "type": "Unprojected",
+            "keywords": [
+                "COPERNICUS",
+                "ESA",
+                "Orthoimagery",
+                "Sentinel-2"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&productType=S2MSI2A&startDate=2022-06-11&completionDate=2022-06-22&maxRecords=10",
@@ -1190,6 +1202,20 @@
                     ]
                 }
             },
+            "keywords": [
+                "raster",
+                "systematic",
+                "satellite imagery",
+                "multi spectral imagery",
+                "climate",
+                "atmospheric aerosols",
+                "marine biology",
+                "maritime monitoring",
+                "OLCI",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "license":"proprietary",
             "links": [
                 {
@@ -1257,6 +1283,20 @@
                     ]
                 }
             },
+            "keywords": [
+                "raster",
+                "systematic",
+                "satellite imagery",
+                "multi spectral imagery",
+                "climate",
+                "atmospheric aerosols",
+                "marine biology",
+                "maritime monitoring",
+                "OLCI",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
@@ -1435,7 +1475,6 @@
             },
             "keywords": [
                 "sentinel hub",
-                "xcube",
                 "raster",
                 "systematic",
                 "multi spectral imagery",
@@ -1447,7 +1486,8 @@
                 "open data",
                 "race challenges",
                 "copernicus",
-                "sentinel"
+                "sentinel",
+                "SLSTR"
             ],
             "license":"proprietary",
             "links": [
@@ -1597,6 +1637,22 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "climate",
+                "atmospheric aerosols",
+                "LST",
+                "SST",
+                "active fires",
+                "open data",
+                "race challenges",
+                "copernicus",
+                "sentinel",
+                "SLSTR"
+            ],
             "license":"proprietary",
             "links": [
                 {
@@ -1658,6 +1714,22 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "climate",
+                "atmospheric aerosols",
+                "LST",
+                "SST",
+                "active fires",
+                "open data",
+                "race challenges",
+                "copernicus",
+                "sentinel",
+                "SLSTR"
+            ],
             "summaries": {
                 "DataAvailability":
                 [
@@ -1761,6 +1833,15 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
@@ -1823,6 +1904,15 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
@@ -1885,6 +1975,15 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",
@@ -1947,6 +2046,15 @@
                     ]
                 }
             },
+            "keywords": [
+                "sentinel hub",
+                "raster",
+                "systematic",
+                "multi spectral imagery",
+                "open data",
+                "copernicus",
+                "sentinel"
+            ],
             "links": [
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel3/search.json?",

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -407,6 +407,8 @@
             "description": "[Sentinel-2 Level 2A](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-2a){target='_blank'} Level 2A product provides atmospherically corrected Surface Reflectance (SR) images, derived from the associated Level-1C products. The atmospheric correction of Sentinel-2 images includes the correction of the scattering of air molecules (Rayleigh scattering), of the absorbing and scattering effects of atmospheric gases, in particular ozone, oxygen and water vapour and the correction of absorption and scattering due to aerosol particles. Level 2A product are considered an ARD product.",
             "mission": "Sentinel-2",
             "constellation": "sentinel-2",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S2_-znk9xsj",
             "gsd": 10,
             "revisit":5,
             "type": "ARD",
@@ -448,6 +450,10 @@
                 "TOC"
             ],
             "links": [
+                {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S2_-znk9xsj"                    
+                },
                 {
                     "rel": "license",
                     "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",

--- a/Data/collections.json
+++ b/Data/collections.json
@@ -5,6 +5,7 @@
             "title": "Sentinel-1 Level 1 Ground Range Detected (GRD)",
             "description": "The [Sentinel 1 Level 1 GRD](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-1){target='_blank'} products in this Collection consist of focused SAR data that has been detected, multi-looked and projected to ground range using the Earth ellipsoid model WGS84. The ellipsoid projection of the GRD products is corrected using the terrain height specified in the product general annotation. The terrain height used varies in azimuth but is constant in range (but can be different for each IW/EW sub-swath). Ground range coordinates are the slant range coordinates projected onto the ellipsoid of the Earth. Pixel values represent detected amplitude. Phase information is lost. The resulting product has approximately square resolution pixels and square pixel spacing with reduced speckle at a cost of reduced spatial resolution.",
             "constellation": "Sentinel-1",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -194,6 +195,7 @@
             "title": "Sentinel-1 Level 1 Single Look Complex (SLC)",
             "description": "The [Sentinel 1 Level 1 SLC](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1-algorithms/single-look-complex){target='_blank'}  products are images in the slant range by azimuth imaging plane, in the image plane of satellite data acquisition. Each image pixel is represented by a complex (I and Q) magnitude value and therefore contains both amplitude and phase information. Each I and Q value is 16 bits per pixel. The processing for all SLC products results in a single look in each dimension using the full available signal bandwidth. The imagery is geo-referenced using orbit and attitude data from the satellite. ",
             "constellation": "Sentinel-1",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -289,6 +291,7 @@
             "title": "Sentinel-1 Level 2 Ocean (OCN)",
             "description": "The [Sentinel-1 Level 2 OCN (Ocean)](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-2){target='_blank'} products are specifically processed radar data products for oceanographic applications. These products are derived from Sentinel-1 SAR data. They are tailored to meet the needs of oceanographic studies, such as monitoring sea surface conditions, detecting oil spills, tracking marine vessels, and studying ocean currents. The OCN products typically involve specialized processing techniques to extract relevant oceanographic information from the radar data. This can include surface wave analysis, wind speed and direction estimation, ocean surface current mapping, and identifying features such as oil slicks or marine traffic.",
             "constellation": "Sentinel-1",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -358,6 +361,7 @@
             "title": "Sentinel-1 Level 0",
             "description": "The [Sentinel-1 Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-1-sar/product-types-processing-levels/level-0){target='_blank'} products are unprocessed radar measurements obtained by the satellite's SAR system, containing amplitude and phase information. They serve as the initial input for generating higher-level radar products with calibrated and corrected data.",
             "constellation": "Sentinel-1",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "keywords": [
                 "raster",
@@ -673,6 +677,8 @@
             "title": "Sentinel-2 Level 1C Top of Atmosphere (TOA)",
             "description": "[Sentinel-2 Level 1C](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1c){target='_blank'} products are available globally from 2015 onwards. These products are resampled with a constant Ground Sampling Distance (GSD) of 10, 20 and 60 m, depending on the native resolution of the different spectral bands. Pixel coordinates refer to the upper left corner of the pixel. ",
             "constellation": "Sentinel-2",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S2_-742ikth",
             "gsd": 10,
             "revisit":5,
             "LevelID":"Level-1",
@@ -728,6 +734,10 @@
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&productType=S2MSI1C&startDate=2022-06-11&completionDate=2022-06-22&maxRecords=10",
                     "rel": "opensearch"
+                },
+                {
+                    "rel":"cite-as",
+                    "href":"https://doi.org/10.5270/S2_-742ikth"
                 },
                 {
                     "href": "https://services.sentinel-hub.com/ogc/wmts/ef291c3e-77fd-43f2-a885-dced9ac1e6a7",
@@ -884,6 +894,7 @@
             "title": "Sentinel-2 Level 1B",
             "description": "The [Sentinel-2 Level 1B](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/product-types/level-1b){target='_blank'} product provides radiometrically corrected imagery in Top-Of-Atmosphere (TOA) radiance values and in sensor geometry. Additionally, this product includes the refined geometric model which is used to generate the Level 1C product.",
             "constellation": "Sentinel-2",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "type": "Unprojected",
             "keywords": [
@@ -929,6 +940,7 @@
             "title": "Sentinel-2 Level 0",
             "description": "Sentinel-2 Level-0 data is the raw data acquired by the Sentinel-2 satellite before any processing or calibration is applied. The purpose of Sentinel-2 Level-0 data is to provide a baseline for further processing and analysis of the images. Before the data can be used for scientific or operational applications, it must be preprocessed to correct for geometric distortions, radiometric calibration, atmospheric corrections, and other factors that can affect the accuracy and quality of the data.",
             "constellation": "Sentinel-2",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "type": "Unprojected",
             "keywords": [
@@ -941,6 +953,10 @@
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?cloudCover=[0,10]&productType=S2MSI2A&startDate=2022-06-11&completionDate=2022-06-22&maxRecords=10",
                     "rel": "opensearch"
+                },
+                {
+                    "rel":"cite-as",
+                    "href":"https://doi.org/10.5270/S2_-d8we2fl"
                 },
                 {
                     "href": "https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-2-msi/product-types/level-0",
@@ -967,6 +983,7 @@
             "title": "Sentinel-3 OLCI Level 1",
             "description": "The [Sentinel-3 OLCI Level 1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-1){target='_blank'} products provides calibrated, geolocated, and orthorectified data from the Ocean and Land Colour Instrument (OLCI). These products are delivered not later than 1 month (commitment) after acquisition or from long-term archives. ",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "gsd":300,
             "assets": {
@@ -1185,6 +1202,7 @@
             "title": "Sentinel-3 OLCI Level 2",
             "description": "The [Sentinel-3 OLCI Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-2){target='_blank'} product provides geophysical data that is derived from the Level-1 product. These products contains retrieved geophysical parameters, such as chlorophyll-a concentration, total suspended matter, and inherent optical properties of water.The Level-2 product also includes data quality flags that provide information on the reliability of the geophysical parameters, as well as information on the atmospheric correction applied to the data. These flags can be used to filter out data that is not of sufficient quality for a particular application.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-2",
             "gsd":300,
             "extent": {
@@ -1266,6 +1284,7 @@
             "title": "Sentinel-3 OLCI Level 0",
             "description": "The [Sentinel-3 OLCI Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-olci/processing-levels/level-0){target='_blank'}  is the reconstructed and time-sorted Instrument Source Packet (ISP) at full space-time resolution. The first part of the process involves unpacking the ISPs, performing a quality check and appending annotation data to them. Once the input raw data files are read, all necessary data are extracted and parsed. The ISPs are then sorted and checked, including missing and duplicated packet numbering. The final part of the processing is the Level-0 product generation. Several quality flags are computed and included in the associated metadata. Raw data, time sorted and annotated are included in the Level-0 package.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "gsd":300,
             "extent": {
@@ -1447,6 +1466,7 @@
             "title": "Sentinel-3 SLSTR Level 1",
             "description": "The [Sentinel-3 SLSTR Level-1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-1){target='_blank'} product provides a valuable source of processed and calibrated data that is suitable for a wide range of applications. The product includes key parameters and data quality flags that provide important information on the reliability and accuracy of the data, and the product is generated offline with a delay of a few days after the acquisition of the Level-0 data.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "assets": {
                 "thumbnail": {
@@ -1621,6 +1641,7 @@
             "title": "Sentinel-3 SLSTR Level 2",
             "description": "The [Sentinel-3 SLSTR Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-2){targte='_blank'} product provides higher-level geophysical parameters, but with a longer processing time and coarser spatial resolution compared to the Level-1 product. The product also includes additional data quality flags to provide more information on the reliability and accuracy of the data.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -1697,6 +1718,7 @@
             "title": "Sentinel-3 SLSTR Level 0",
             "description": "The [Sentinel-3 SLSTR Level 0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-slstr/processing-levels/level-0){target='_blank'} product is the raw unprocessed data acquired by the SLSTR instrument on board the Sentinel-3 satellite. It consists of the uncalibrated digital counts received by the SLSTR detectors for each pixel in the image. It provides a valuable source of unprocessed data for researchers and advanced users who require access to the raw data for their applications. ",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "gsd":500,
             "extent": {
@@ -1817,6 +1839,7 @@
             "title": "Sentinel-3 SYN Level 2",
             "description": "The [Sentinel-3 SYN Level 2 ](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-3/data-products/synergy){target='blank'} product is a higher-level processed product that contains information about the Earth's atmosphere and its constituents.  It is derived from the Level-1 and Level-2 products of the OLCI and SLSTR instruments on board the Sentinel-3 satellite.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -1888,6 +1911,7 @@
             "title": "Sentinel-3 SRAL Level 1",
             "description": "The [Sentinel-3 SRAL Level-1](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-1){target='blank'} product provides corrected and validated geophysical parameters derived from the raw SRAL Level-0 data, along with metadata and data quality flags that enable the user to assess the reliability and suitability of the data for specific applications.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-1",
             "extent": {
                 "spatial": {
@@ -1959,6 +1983,7 @@
             "title": "Sentinel-3 SRAL Level 2",
             "description": "The [Sentinel-3 SRAL Level-2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-2){target='blank'} product is a higher-level processed product that contains more detailed and refined geophysical parameters suitable for scientific and research applications. It contains advanced geophysical parameters such as sea surface height, significant wave height, and wind speed, that are derived from the SRAL Level-1 products using advanced processing algorithms and quality control procedures.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-2",
             "extent": {
                 "spatial": {
@@ -2030,6 +2055,7 @@
             "title": "Sentinel-3 SRAL Level 0",
             "description": "The [Sentinel-3 Synthetic Aperture Radar Altimeter (SRAL) Level-0](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-3-altimetry/processing-levels/level-0){target='_blank'} product contains raw data acquired by the SRAL instrument onboard the Sentinel-3 satellite. The data contains raw, time-tagged radar echoes and instrument housekeeping data, along with metadata describing the acquisition parameters and instrument characteristics.",
             "constellation": "Sentinel-3",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "extent": {
                 "spatial": {
@@ -2084,6 +2110,8 @@
             "title": "Sentinel-5P Level 2 Aerosol Index",
             "description": "The [Sentinel-5P Level 2 Aerosol Index (AER_AI)](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-uv-aerosol-index-atbd?){target='_blank'} dataset provides high-resolution imagery of the UV Aerosol Index (UVAI), also called the Absorbing Aerosol Index (AAI). The AAI is based on wavelength-dependent changes in Rayleigh scattering in the UV spectral range for a pair of wavelengths. The difference between observed and modelled reflectance results in the AAI. When the AAI is positive, it indicates the presence of UV-absorbing aerosols like dust and smoke. It is useful for tracking the evolution of episodic aerosol plumes from dust outbreaks, volcanic ash, and biomass burning.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-3dgz66p",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2137,6 +2165,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-3dgz66p"                    
+                },
+                {
                     "rel": "license",
                     "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
                     "type": "application/pdf"
@@ -2173,6 +2205,8 @@
             "title": "Sentinel-5P Level 2 Carbon Monoxide",
             "description": "The [Sentinel-5P Level 2 CO](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-carbon-monoxide-level-2-product-readme-file?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission, specifically focusing on measuring and analyzing the concentration of carbon monoxide in the Earth's atmosphere. It includes data on the total column carbon monoxide content, as well as vertical profiles that describe how the concentration changes with altitude.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-bj3nry0",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2211,6 +2245,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-bj3nry0"                    
+                },
+                {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__CO____%20AND%20processingmode:Offline",
                     "rel": "opensearch"
                 }
@@ -2242,6 +2280,8 @@
             "title": "Sentinel-5P Level 2 Cloud",
             "description": "The [Sentinel-5P Level 2 Cloud](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-cloud-products-atbd?){target='_blank'} dataset provides high-resolution imagery of cloud parameters. The TROPOMI/S5P cloud properties retrieval is based on the OCRA and ROCINN algorithms currently being used in the operational GOME and GOME-2 products. OCRA retrieves the cloud fraction using measurements in the UV/VIS spectral regions and ROCINN retrieves the cloud height (pressure) and optical thickness (albedo) using measurements in and around the oxygen A-band at 760 nm. Additionally, the cloud parameters are also provided for a cloud model which assumes the cloud to be a Lambertian reflecting boundary.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-ry8kaa5",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2296,6 +2336,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-ry8kaa5"                    
+                },
+                {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__CLOUD_%20AND%20processingmode:Offline",
                     "rel": "opensearch"
                 }
@@ -2327,6 +2371,8 @@
             "title": "Sentinel-5P Level 2 Formaldehyde",
             "description": "The [Sentinel-5P Level 2 HCHO](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-formaldehyde-level-2-readme?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focus on measuring and analyzing the concentration of formaldehyde in the Earth's atmosphere. The Level 2 Formaldehyde data also incorporates auxiliary information, such as geolocation, cloud properties, and surface reflectance, which are crucial for contextualizing and interpreting the measurements.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-vg1i7t0",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2363,6 +2409,10 @@
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-formaldehyde",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-vg1i7t0"                    
                 },
                 {
                     "rel": "license",
@@ -2415,6 +2465,8 @@
             "title": "Sentinel-5P Level 2 Methane",
             "description": "The [Sentinel-5P Level 2 CH4](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-methane-product-readme-file?){target='_blank'} data from the Copernicus Sentinel-5P satellite shows the methane concentrations globally. This product provides processed and derived measurements of methane concentrations in the Earth's atmosphere. It is a valuable resource for studying climate change, understanding methane emissions, and informing environmental policies and mitigation efforts.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-3lcdqiv",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2453,6 +2505,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-3lcdqiv"                    
+                },
+                {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__CH4___%20AND%20processingmode:Offline",
                     "rel": "opensearch"
                 }
@@ -2484,6 +2540,8 @@
             "title": "Sentinel-5P Level 2 Nitrogen Dioxide",
             "description": "The [Sentinel-5P Level 2 NO2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-tropomi-level-2-product-user-manual-nitrogen-dioxide?){target='_blank'} data comes from the Copernicus Sentinel-5P satellite and shows the nitrogen dioxide concentrations across the globe. Concentrations of short-lived pollutants, such as nitrogen dioxide, are indicators of changes in economic slowdowns and are comparable to changes in emissions.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-9bnp8q8",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2520,6 +2578,10 @@
                     "href": "https://sentinel.esa.int/web/sentinel/data-products/-/asset_publisher/fp37fc19FN8F/content/sentinel-5-precursor-level-2-nitrogen-dioxide",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-9bnp8q8"                    
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__NO2___%20AND%20processingmode:Offline",
@@ -2560,6 +2622,8 @@
             "description": "The [Sentinel-5P Level 2 O3](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-ozone-profile-product-readme-file?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focuses on measuring and analyzing the concentration and distribution of ozone in the Earth's atmosphere. Researchers and scientists utilize this data for various purposes, that includes monitoring and assessing ozone depletion, particularly in regions like the polar areas, where the ozone layer is crucial. Additionally, the data aids in air quality monitoring, enabling the evaluation of ozone pollution control measures and understanding of pollution sources. ",
             "constellation": "Sentinel-5P",
             "LevelID":"Level-2",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-ft13p57",
             "assets": {
                 "thumbnail": {
                     "href": "https://developers.google.com/earth-engine/datasets/images/COPERNICUS/COPERNICUS_S5P_NRTI_L3_O3_sample.png",
@@ -2608,6 +2672,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-ft13p57"                    
+                },
+                {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json?&filter=producttype:L2__O3____%20AND%20processingmode:Offline",
                     "rel": "opensearch"
                 }
@@ -2639,6 +2707,8 @@
             "title": "Sentinel-5P Level 2 Sulfur Dioxide",
             "description": "The [Sentinel-5P Level 2 SO2](https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-5p-tropomi/document-library/-/asset_publisher/w9Mnd6VPjXlc/content/sentinel-5p-sulphur-dioxide-level-2-readme?){target='_blank'} data refers to processed and derived datasets obtained from the Sentinel-5P satellite mission that focuses on measuring and analyzing the concentration and distribution of sulfur dioxide in the Earth's atmosphere. It provides comprehensive information on atmospheric sulfur dioxide's vertical distribution and spatial variations. It includes data on the total column sulfur dioxide content and vertical profiles that describe how the concentration changes with altitude. This data also incorporates auxiliary information, such as geolocation, cloud properties, and surface reflectance, which are crucial for contextualising and interpreting the measurements.  It is a valuable resource for studying air quality, volcanic activity, atmospheric chemistry, and assessing the impacts of sulfur dioxide on human health and the environment.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-yr8kdpp",
             "LevelID":"Level-2",
             "assets": {
                 "thumbnail": {
@@ -2691,6 +2761,10 @@
                     "rel": "about"
                 },
                 {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-yr8kdpp"                    
+                },
+                {
                     "rel": "license",
                     "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice",
                     "type": "application/pdf"
@@ -2727,12 +2801,18 @@
             "title": "Sentinel-5P Level 1B",
             "description": "The [Sentinel-5P Level 1B](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-5p/products-algorithms/level-1b){target='_blank'} data refers to a processed and calibrated dataset derived from the raw measurements acquired by the Sentinel-5P satellite. This level of data undergoes initial processing steps to correct for instrument effects, atmospheric disturbances, and other artifacts. ",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
+            "sci:doi": "10.5270/S5P-mhtbru8",
             "LevelID":"Level-1",
             "links": [
                 {
                     "href": "https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-5p/products-algorithms/level-1b",
                     "title": "User guide",
                     "rel": "about"
+                },
+                {
+                    "rel":"cite-as",
+                    "href": "https://doi.org/10.5270/S5P-mhtbru8"                    
                 },
                 {
                     "href": "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel5P/search.json",
@@ -2757,6 +2837,7 @@
             "title": "Sentinel-5P Level 0",
             "description": "The [Sentinel-5P Level 0](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-5p/products-algorithms/level-0){target='_blank'} data refers to the raw data acquired by the Sentinel-5P satellite during its mission. These instruments include the Tropospheric Monitoring Instrument (TROPOMI), which is capable of measuring a wide range of atmospheric pollutants such as nitrogen dioxide, ozone, formaldehyde, and aerosols, among others.",
             "constellation": "Sentinel-5P",
+            "sci:citation": "Copernicus Sentinel data 2023",
             "LevelID":"Level-0",
             "keywords": [
                 "aai",


### PR DESCRIPTION
Hi @Pratichhya  I managed to do a more detailed review of STAC metadata:

- temporal extent was invalid: this may break your rendering! As a quick fix, you could consider putting the previous value in a custom property, although it shouldn't be impossible to write conversion logic either.
- some keywords were present that are not relevant in dataspace context
- license link was missing, maybe still needs to be added to other collections as well. If license is set to proprietary, the link needs to be there. Can we also add a button with the license? 
- constellation seems to be preferred over mission, and has standardized values
