### PR TITLE
Migrated submodule to publish branch

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -70,18 +70,18 @@ website:
               text: Using JavaScript client
             - href: "APIs/openEO/job_config.qmd"
               text: Job configuration
-            # - section: "Jupyter notebooks"
-            #   contents:
-            #   - href: "notebook-samples/openeo/NDVI_Timeseries.ipynb"
-            #     text: "Zonal statistics over time"
-            #   - href: "notebook-samples/openeo/Load_Collection.ipynb"
-            #     text: "Load Sentinel-2 data"
-            #   - href: "notebook-samples/openeo/UDF.ipynb"
-            #     text: User defined functions
-            #   - href: "notebook-samples/openeo/UDP.ipynb"
-            #     text: Publishing workflow as a service
-            #   - href: "APIs/openEO/openeo-community-examples/python/BasicSentinelMerge/sentinel_merge.ipynb"
-            #     text: "Preprocessing & merging Sentinels"
+            - section: "Jupyter notebooks"
+              contents:
+              - href: "notebook-samples/openeo/NDVI_Timeseries.ipynb"
+                text: "Zonal statistics over time"
+              - href: "notebook-samples/openeo/Load_Collection.ipynb"
+                text: "Load Sentinel-2 data"
+              - href: "notebook-samples/openeo/UDF.ipynb"
+                text: User defined functions
+              - href: "notebook-samples/openeo/UDP.ipynb"
+                text: Publishing workflow as a service
+              - href: "APIs/openEO/openeo-community-examples/python/BasicSentinelMerge/sentinel_merge.ipynb"
+                text: "Preprocessing & merging Sentinels" 
           - href: APIs/STAC.md
           - href: APIs/S3.md
             text: S3 Access

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -80,8 +80,8 @@ website:
                 text: User defined functions
               - href: "notebook-samples/openeo/UDP.ipynb"
                 text: Publishing workflow as a service
-              - href: "APIs/openEO/openeo-community-examples/python/BasicSentinelMerge/sentinel_merge.ipynb"
-                text: "Preprocessing & merging Sentinels" 
+              # - href: "APIs/openEO/openeo-community-examples/python/BasicSentinelMerge/sentinel_merge.ipynb"
+              #   text: "Preprocessing & merging Sentinels" 
           - href: APIs/STAC.md
           - href: APIs/S3.md
             text: S3 Access


### PR DESCRIPTION
When the staging branch was merged with the publish branch, it didn't migrate the submodules rendering. Therefore, currently, it is commented out in the publish branch to avoid "NOT FOUND" page.

This PR includes updates of the submodule for eu-cdse/notebook-samples and is now rendered but it seems like this was not a good method I adopted and is not similar to what @jdries did. As here, you will find the entire repo is also cloned. So it needs fixing.

Furthermore, Open-EO/openeo-community-examples.git  submodule hasn't been updated yet due to access permission. 