### PR TITLE
Landsat 5, 7 and 8 are added to the DataTable

### DIFF
--- a/Roadmap/DataTable.qmd
+++ b/Roadmap/DataTable.qmd
@@ -252,6 +252,30 @@ format:
                 <td></td>
                 <td></td>
             </tr>
+            <tr class="cod">
+                <td>Landsat 5</td>
+                <td></td>
+                <td></td>
+                <td>Start of gradual publication</td>
+                <td></td>
+                <td></td>
+            </tr>
+            <tr class="cod">
+                <td>Landsat 7</td>
+                <td></td>
+                <td></td>
+                <td>Start of gradual publication</td>
+                <td></td>
+                <td></td>
+            </tr>
+            <tr class="cod">
+                <td>Landsat 8</td>
+                <td></td>
+                <td></td>
+                <td>Start of gradual publication</td>
+                <td></td>
+                <td></td>
+            </tr>
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
Landsat 5, 7 and 8 are added to the DataTable, to complete the list of data available on the Copernicus Data Space Ecosystem.