### PR TITLE
Fix link to QGIS application in sidebar

### DIFF
--- a/Applications/QGIS.qmd
+++ b/Applications/QGIS.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Sentinel Hub QGIS Python Plugin"
+title: "Sentinel Hub QGIS Plugin"
 ---
 
 The Sentinel Hub QGIS Plugin allows you to view satellite image data from the Copernicus Data Space Ecosystem or from Sentinel Hub directly within a QGIS workspace. All datasets are available that are part of collections associated with your user, including commercial data within Sentinel Hub subscriptions and Bring Your Own COG datasets in Sentinel Hub and Copernicus Data Space. The current functionality of the QGIS Plugin is for visualization; it does not allow you to perform operations or access properties of the dataset. For individual downloads, we recommend the [Copernicus Browser](https://dataspace.copernicus.eu/browser/){target="_blank"}; for downloading multiple datasets for an area and time period of interest in a graphical interface, [Request Builder](https://shapps.dataspace.copernicus.eu/requests-builder/){target="_blank"} is the optimal tool. 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -135,8 +135,8 @@ website:
                     text: Time Series
                   - href: "APIs/SentinelHub/UserGuides/Metadata.qmd"
                     text: Working with metadata in evalscript
-                  - href: "Applications/QGIS.qmd"
-                    text: QGIS Plugin
+                  # - href: "Applications/QGIS.qmd"
+                  #   text: QGIS Plugin
               - section: "Data"
                 href: "APIs/SentinelHub/Data.qmd"
                 contents:


### PR DESCRIPTION
The first reference to the QGIS documentation/user guide in the `_quarto.yaml` file was actually in `APIs/Sentinel Hub/User guides`, which caused the sidebar to jump to that folder when clicking on the user guide under `Applications/QGIS Plugin`.