### PR TITLE
included external guide links

### DIFF
--- a/APIs/openEO/job_config.qmd
+++ b/APIs/openEO/job_config.qmd
@@ -43,6 +43,8 @@ This is a short overview of the various options:
 - `logging-threshold`: the threshold for logging, set to 'info' by default, can be set to 'debug' to generate much more logging
 - `udf-dependency-archives`: an array of urls pointing to zip files with extra dependencies, see below
 
+If you're interested in delving further into the terminology associated with Kubernetes and how they are used, please have a look at [this page](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/){target="_blank"}, which provides a detailed walkthrough of the general idea on resource allocation.
+
 ### Custom UDF dependencies
 
 User defined functions often depend on (specific versions of) libraries or require small auxiliary data files. The UDF specifications do not yet


### PR DESCRIPTION
included external links to the technical background involved in the resource allocation. 

@jdries, @soxofaan please let me know if you have any feedback or comments on the placement of the link within the documentation, otherwise, I can merge it as it would be a simple link alone. 