### PR TITLE
openEO: add 2 pages with details

### DIFF
--- a/APIs/openEO/openEO.qmd
+++ b/APIs/openEO/openEO.qmd
@@ -14,6 +14,8 @@ jupyter: python3
 
 With openEO's collaborative nature, users can seamlessly share code, workflows, and data processing methods across platforms and tools, fostering collaboration and advancing the accessibility, scalability, and reproducibility of Earth observation data. Additionally, openEO provides intuitive programming libraries that enable easy analysis of diverse Earth observation datasets. These libraries facilitate efficient access and processing of large-scale data across multiple infrastructures, supporting various applications, including exploratory research, detailed mapping, and information extraction from Earth observation. Moreover, this streamlined approach enhances the development process, enabling the utilization of Earth observation data for a wide range of applications and services.
 
+The endpoint for the public service is 100% open source and compatible with Pangeo technology. Read more about it [here](APIs/openEO/openeo_deployment.md).
+
 Endpoint: [https://openeo.dataspace.copernicus.eu/](https://openeo.dataspace.copernicus.eu/){target="_blank"}
 
 ## Added-value of openEO API
@@ -28,7 +30,7 @@ The key benefits of using openEO API can be summarized as follows:
 
 When using the openEO API, users can choose [JavaScript](JavaScript_Client/JavaScript.qmd), [Python](Python_Client/Python.qmd), or [R](R_Client/R.qmd) as their client library. This allows them to work with any back-end and compare them based on capacity, cost, and result quality.
 
-Nevertheless, if you are not familiar with programming, you could start using the [web-based editor for openEO](#). It supports visual modelling of your algorithms and simplified JavaScript-based access to the openEO workflows and providers. An overview of the openEO web-editor is available in the [Applications](https://documentation.dataspace.copernicus.eu/Applications.html) section of this documentation. 
+Nevertheless, if you are not familiar with programming, you could start using the [web-based editor for openEO](#). It supports visual modelling of your algorithms and simplified JavaScript-based access to the openEO workflows and providers. An overview of the openEO web-editor is available in the [Applications](https://documentation.dataspace.copernicus.eu/Applications.html) section of this documentation.
 
 ## Datacubes
 

--- a/APIs/openEO/openeo_deployment.md
+++ b/APIs/openEO/openeo_deployment.md
@@ -1,6 +1,6 @@
 # openEO public service deployment
 
-The openEO deployment of the CDSE public service has the aim to protect against lock-in in various ways:
+The openEO deployment of the Copernicus Data Space Ecosystem public service has the aim to protect against lock-in in various ways:
 - The software is 100% open source, preventing dependency on a vendor. 
 - openEO is an open standard, with a web service API. Allowing to immediately switch to other API's that implement openEO.
 - openEO workflows use standardized processes. Avoiding that your worflows are strongly coupled to a specific technology. 

--- a/APIs/openEO/openeo_deployment.md
+++ b/APIs/openEO/openeo_deployment.md
@@ -1,0 +1,67 @@
+# openEO public service deployment
+
+The openEO deployment of the CDSE public service has the aim to protect against lock-in in various ways:
+- The software is 100% open source, preventing dependency on a vendor. 
+- openEO is an open standard, with a web service API. Allowing to immediately switch to other API's that implement openEO.
+- openEO workflows use standardized processes. Avoiding that your worflows are strongly coupled to a specific technology. 
+
+## Deployment
+
+### Data access
+
+The service runs on Cloudferro and T-Systems infrastructure, close to the storage systems that store the Sentinel
+archives. It also reads from these archives directly and processes the data on the fly. For complex products like
+Sentinel-1, we have the sar_backscatter process that performs on the fly orthorectification. 
+
+For products like Sentinel-2, with lots of overlap, we have custom code in place to resolve this as efficiently
+and correctly as possible. 
+
+We tune settings of data access libraries like GDAL to the specific needs of the clouds that we work with. This
+is a tedious process and subject to change. When you observe suboptimal data access performance, it may be good
+to enquire about this.
+
+#### Sentinelhub API data access
+
+Some datasets are accessed via the Sentinelhub API instead of the raw files. This is done to provide a 
+cost-effective deployment, and be able to offer a wide choice of datasets which would otherwise be impossible.
+
+### Processing
+
+Processing happens on a Kubernetes cluster with auto-scaling capabilities. In that cluster, your jobs run as
+Apache Spark applications. This is a very widely used and mature big data processing framework. It is comparable
+to Dask, which mostly focuses on being a pure-Python implementation.
+
+We currently do not have benchmarks that rigorously compare the performance of openEO with other processing
+frameworks, but we can make some relevant observations:
+
+- There's no technical evidence that, by design, other processing approaches are somehow better or faster.
+- We have validated the backend by running large scale processing tasks, and achieved results that matched and 
+sometimes even exceeded the expectations with respect to processing budgets.
+- The use of a service such as openEO implies significant cost savings in terms of personnel costs compared to
+an approach based on infrastructure as a service (IAAS).
+- The main cost driver and performance bottleneck of many EO workflows is the data access performance, which is 
+relatively independent of the software, assuming that tuning parameters are properly set.
+
+The openEO backend will try to automatically determine performance-sensitive parameters of your processing job.
+This includes settings for memory, cores and data partitioning/chunking. It is however possible that the automatic 
+tuning is not working for your use case. A typical situation is that workflows require more memory, but someties
+also more advanced tuning such as partitioning needs to be applied.
+
+### Deploying your own backend
+
+Just like any other backend you can run your own batch jobs using the open source software, and the public docker image.
+
+At openEO.org, you can find [a list](https://openeo.org/software.html#back-ends) of open source implementations.
+There's also [some guidance](https://openeo.org/documentation/1.0/developers/backends/getting-started.html) for 
+getting started as a service provider.
+
+To run your own small scale testing locally, we can recommend the Pangeo based 
+['local processing'](https://open-eo.github.io/openeo-python-client/cookbook/localprocessing.html) feature.
+
+### Alternative backends & deployments
+
+The openEO Hub maintains a list of other openEO services: https://hub.openeo.org
+
+
+
+

--- a/APIs/openEO/openeo_processing.md
+++ b/APIs/openEO/openeo_processing.md
@@ -1,0 +1,32 @@
+# openEO process implementation details
+
+This page details a number of relevant aspects on the implementations of specific
+openEO processes that are relevant for reproducibility.
+
+The openEO deployment of CDSE public service is 100% open source, and has the
+specific goal of supporting open science.
+
+## SAR backscatter
+
+The sar_backscatter process allows on the fly computation of Sentiinel-1 sigma0 backscatter. It is based
+on the open source Orfeo Toolbox and sufficiently fast to provide a cost-effective option for large scale
+processing.
+
+### Known issues
+
+When thermal noise is removed, values are set to 0, but Orfeo also uses 0 for nodata.
+
+## load_collection
+
+The load_collection implementation is quite advanced and tries to optimize data loading from the data space archive.
+
+When no resampling options are specified in the process graph, we try to respect the original pixel grid of the data.
+This is done to allow processing that is equally exact as file based processing.
+
+### Known issues
+
+Property filtering depends on the data space catalog, which has limited STAC capabilities for the moment. 
+This sometimes prevents the usage of standardized STAC property names, which affects the portability of 
+other process graphs.
+
+


### PR DESCRIPTION
In response to user feedback, I added 2 pages:

A deployment page that details that our backend actually runs on CDSE IAAS and actually does read from the archive directly.

A processes details page where we can document implementation details that some users are asking for. 