### PR TITLE
commented out issue url

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,7 +6,7 @@ website:
   repo-url: "https://github.com/eu-cdse/documentation"
   repo-branch: "publish"
   site-url: "https://documentation.dataspace.copernicus.eu/"
-  issue-url: "https://github.com/eu-cdse/documentation/issues"
+  # issue-url: "https://github.com/eu-cdse/documentation/issues"
   site-path: '/Home.html'
   search:
     location: sidebar


### PR DESCRIPTION
Commented out the issue-url instead. I tried adding adding something like repo-actions: [] or repo-actions: [none]
 as suggested in #354 . However, it didnt work, therefore as a work arround I comment out the url. 
