### PR TITLE
updated css to fix table width

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -432,3 +432,7 @@ input, .search-result-header, .search-result-container, .search-result-section, 
    position: sticky;
    top: 0;
 }
+
+.header {
+   word-wrap: break-word;
+}


### PR DESCRIPTION
The table header generated by rendering quarto seems to have been messed up as seen in https://documentation.dataspace.copernicus.eu/notebook-samples/sentinelhub/migration_from_scihub_guide.html

Therefore wrapped the text around when needed.