### PR TITLE
moved content at the buttom of the page

### DIFF
--- a/APIs/openEO/job_config.qmd
+++ b/APIs/openEO/job_config.qmd
@@ -1,10 +1,3 @@
-## Validity of signed URLs in batch job results
-
-Batch job results are accessible to the user via signed URLs stored in the result assets. Within the platform,
-these URLs have a validity (expiry time) of 7 days. Within these 7 days, the results of a batch job can be accessed
-by any person with the URL. Each time a user requests the results from the job endpoint (`GET /jobs/{job_id}/results`),
-a freshly signed URL (valid for 7 days) is created for the result assets.
-
 ## Customizing batch job resources
 
 Jobs running on the cloud get assigned a default amount of CPU and memory resources. This
@@ -64,6 +57,13 @@ Known limitations:
 - Your dependencies need to be compatible with the Python version of the backend, currently 3.8.
 - Your dependencies need to be compatible with the OS of the backend, currently AlmaLinux 8.
 - The backend has a limited set of Python dependencies that are preloaded, and cannot be changed, such as numpy.
+
+## Validity of signed URLs in batch job results
+
+Batch job results are accessible to the user via signed URLs stored in the result assets. Within the platform,
+these URLs have a validity (expiry time) of 7 days. Within these 7 days, the results of a batch job can be accessed
+by any person with the URL. Each time a user requests the results from the job endpoint (`GET /jobs/{job_id}/results`),
+a freshly signed URL (valid for 7 days) is created for the result assets.
 
 
 ### Learning more


### PR DESCRIPTION
Not much changes done in the PR except that the section on **Validity of signed URLs in batch job results** is moved a bit toward the buttom of the page as it was mention to have less priority. 