### PR TITLE
included aliases in data section

### DIFF
--- a/APIs/openEO/Collections.qmd
+++ b/APIs/openEO/Collections.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Data collections"
+aliases: 
+  - collections.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/File_formats.qmd
+++ b/APIs/openEO/File_formats.qmd
@@ -1,5 +1,7 @@
 ---
 title: "File Formats"
+aliases: 
+  - fileformats.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/Glossary.qmd
+++ b/APIs/openEO/Glossary.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Glossary"
+aliases: 
+  - glossary.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/JavaScript_Client/JavaScript.qmd
+++ b/APIs/openEO/JavaScript_Client/JavaScript.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Getting started with JavaScript client"
+aliases: 
+  - javascript.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/Processes.qmd
+++ b/APIs/openEO/Processes.qmd
@@ -1,5 +1,7 @@
 ---
 title: "openEO Processes"
+aliases: 
+  - processes.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/Python_Client/Python.qmd
+++ b/APIs/openEO/Python_Client/Python.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Getting started with the openEO Python client"
+aliases: 
+  - python.html
 format:
   html:
     code-fold: false

--- a/APIs/openEO/R_Client/R.qmd
+++ b/APIs/openEO/R_Client/R.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Getting started with R client"
+aliases: 
+  - r.html
 format:
   html:
     code-fold: true

--- a/APIs/openEO/openEO.qmd
+++ b/APIs/openEO/openEO.qmd
@@ -1,5 +1,7 @@
 ---
 title: "openEO"
+aliases: 
+  - openeo.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/Additional.qmd
+++ b/Data/ComplementaryData/Additional.qmd
@@ -1,5 +1,7 @@
 ---
 title: Additional Data
+aliases: 
+  - /additionaldata.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/CAMS.qmd
+++ b/Data/ComplementaryData/CAMS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Copernicus Atmosphere Monitoring Service (CAMS)"
+aliases: 
+  - /cams.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/CEMS.qmd
+++ b/Data/ComplementaryData/CEMS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Copernicus Emergency Management Service (CEMS)"
+aliases: 
+  - /cems.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/CLMS.qmd
+++ b/Data/ComplementaryData/CLMS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Copernicus Land Monitoring Service (CLMS)"
+aliases: 
+  - /clims.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/CMEMS.qmd
+++ b/Data/ComplementaryData/CMEMS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Copernicus Marine Environment Monitoring Service (CMEMS)"
+aliases: 
+  - /cmems.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/Landsat5.qmd
+++ b/Data/ComplementaryData/Landsat5.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Landsat-5"
+aliases: 
+  - /landsat5.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/Landsat7.qmd
+++ b/Data/ComplementaryData/Landsat7.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Landsat-7"
+aliases: 
+  - /landsat7.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/Landsat8.qmd
+++ b/Data/ComplementaryData/Landsat8.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Landsat-8"
+aliases: 
+  - /landsat8.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/MERIS.qmd
+++ b/Data/ComplementaryData/MERIS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "ENVISAT- Medium Resolution Imaging Spectrometer (MERIS)"
+aliases: 
+  - /meris.html
 format:
   html:
     code-fold: true

--- a/Data/ComplementaryData/SMOS.qmd
+++ b/Data/ComplementaryData/SMOS.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Soil Moisture and Ocean Salinity (SMOS)"
+aliases: 
+  - /smos.html
 format:
   html:
     code-fold: true

--- a/Data/Others/Dashboard.qmd
+++ b/Data/Others/Dashboard.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Copernicus Operations Dashboard"
+aliases: 
+  - /dashboard.html
 ---
 
 ![](_images/Dashboard/Dashboard1.png)

--- a/Data/Others/Sentinel1_COG.qmd
+++ b/Data/Others/Sentinel1_COG.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Handling Sentinel-1 COG_SAFE products "
+aliases: 
+  - /sentinel1COG.html
 format:
   html:
     code-fold: true

--- a/Data/Others/Sentinel2_L1C_baseline.qmd
+++ b/Data/Others/Sentinel2_L1C_baseline.qmd
@@ -1,4 +1,6 @@
 ---
+aliases: 
+  - /sentinel2l1cbaseline.html
 format:
   html:
     code-fold: true

--- a/Data/Others/Sentinel2_L2A_baseline.qmd
+++ b/Data/Others/Sentinel2_L2A_baseline.qmd
@@ -1,4 +1,6 @@
 ---
+aliases: 
+  - /sentinel2l2abaseline.html
 format:
   html:
     code-fold: true

--- a/Data/Others/Sentinel2_Mosaic_Algorithm.qmd
+++ b/Data/Others/Sentinel2_Mosaic_Algorithm.qmd
@@ -1,4 +1,6 @@
 ---
+aliases: 
+  - /sentinel2mosaicalgorithm.html
 format:
   html:
     code-fold: true

--- a/Data/Others/Sentinel2_Mosaic_access.qmd
+++ b/Data/Others/Sentinel2_Mosaic_access.qmd
@@ -1,4 +1,6 @@
 ---
+aliases: 
+  - /sentinel2mosaicaccess.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -1,8 +1,7 @@
 ---
 title: "Sentinel-1"
 aliases: 
-  - Sentinel1.html
-  - Data/Sentinel1.html
+  - /Data/Sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-1"
 aliases: 
-  - /sentinel1.html
+  - /Sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-1"
 aliases: 
-  - Data/Sentinel1.html
+  - Sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -2,6 +2,7 @@
 title: "Sentinel-1"
 aliases: 
   - Sentinel1.html
+  - Data/Sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-1"
 aliases: 
-  - /Sentinel1.html
+  - Data/Sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel1.qmd
+++ b/Data/SentinelMissions/Sentinel1.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sentinel-1"
+aliases: 
+  - /sentinel1.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel2.qmd
+++ b/Data/SentinelMissions/Sentinel2.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-2"
 aliases: 
-  - Data/Sentinel2.html
+  - /Data/Sentinel2.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel2.qmd
+++ b/Data/SentinelMissions/Sentinel2.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-2"
 aliases: 
-  - /sentinel2.html
+  - /Sentinel2.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel2.qmd
+++ b/Data/SentinelMissions/Sentinel2.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sentinel-2"
+aliases: 
+  - /sentinel2.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel2.qmd
+++ b/Data/SentinelMissions/Sentinel2.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-2"
 aliases: 
-  - /Sentinel2.html
+  - Data/Sentinel2.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel3.qmd
+++ b/Data/SentinelMissions/Sentinel3.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-3"
 aliases: 
-  - /Sentinel3.html
+  - /Data/Sentinel3.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel3.qmd
+++ b/Data/SentinelMissions/Sentinel3.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sentinel-3"
+aliases: 
+  - /sentinel3.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel3.qmd
+++ b/Data/SentinelMissions/Sentinel3.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-3"
 aliases: 
-  - /sentinel3.html
+  - /Sentinel3.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-5P"
 aliases: 
-  - /Sentinel5P.html
+  - /Data/Sentinel5P.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-5P"
 aliases: 
-  - /sentinel5p.html
+  - /Sentinel5P.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sentinel-5P"
+aliases: 
+  - /sentinel5p.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel6.qmd
+++ b/Data/SentinelMissions/Sentinel6.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-6"
 aliases: 
-  - /sentinel6.html
+  - /Sentinel6.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel6.qmd
+++ b/Data/SentinelMissions/Sentinel6.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sentinel-6"
+aliases: 
+  - /sentinel6.html
 format:
   html:
     code-fold: true

--- a/Data/SentinelMissions/Sentinel6.qmd
+++ b/Data/SentinelMissions/Sentinel6.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Sentinel-6"
 aliases: 
-  - /Sentinel6.html
+  - /Data/Sentinel6.html
 format:
   html:
     code-fold: true


### PR DESCRIPTION
During maintenance, files and folders are rearranged frequently, which sometimes leads to false URL sharing. Therefore, aliases are introduced in the data section.

This PR is simply a reference to how it is done in quarto files, and it is recommended that it be repeated for almost all the markdowns in the documentation. 