### PR TITLE
openeo restriction when using Sentinel 5P

### DIFF
--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -31,9 +31,9 @@ There are [different data products](https://sentinels.copernicus.eu/web/sentinel
 
 ## Processing restrictions in openEO
 
-In the present implementation of openEO and Sentinel Hub API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
+In the present implementation of openEO and Sentinel Hub API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P collection. 
 
-Hence, if you try to load or process two different bands simultaneously using any of these APIs, like methane and NO2, you'll get an error message indicating that the script can only use one product type at once!.
+Hence, if you try to load or process two different bands simultaneously using any of these APIs, like methane and NO2, you'll get an error message indicating that the script can only use one product type at once.
 
 
 :::

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -31,7 +31,7 @@ There are [different data products](https://sentinels.copernicus.eu/web/sentinel
 
 ## Processing restrictions in openEO
 
-In the present implementation of openEO and Sentinel API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
+In the present implementation of openEO and Sentinel Hub API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
 
 Hence, if you try to load or process two different bands simultaneously using any of these APIs, like methane and NO2, you'll get an error message indicating that the script can only use one product type at once!.
 

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -31,9 +31,9 @@ There are [different data products](https://sentinels.copernicus.eu/web/sentinel
 
 ## Processing restrictions in openEO
 
-In the present implementation of openEO API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
+In the present implementation of openEO and Sentinel API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
 
-Hence, if you try to load or process two different bands simultaneously, like methane and NO2, you'll get an error message saying, "The script can only use one product type at once!"
+Hence, if you try to load or process two different bands simultaneously using any of these APIs, like methane and NO2, you'll get an error message indicating that the script can only use one product type at once!.
 
 
 :::

--- a/Data/SentinelMissions/Sentinel5P.qmd
+++ b/Data/SentinelMissions/Sentinel5P.qmd
@@ -26,3 +26,14 @@ The main objective of the Copernicus Sentinel-5P mission is to perform atmospher
 There are [different data products](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-5p/data-products){target="_blank"} associated with the three levels of TROPOMI processing: Level-0, Level-1B and Level-2.
 
 {{< include ../_render_collections.qmd >}}
+
+:::{.callout-caution}
+
+## Processing restrictions in openEO
+
+In the present implementation of openEO API, users are limited to processing or downloading only one band at a time when dealing with Sentinel 5P data using openEO. 
+
+Hence, if you try to load or process two different bands simultaneously, like methane and NO2, you'll get an error message saying, "The script can only use one product type at once!"
+
+
+:::


### PR DESCRIPTION
There is a specific restriction at the moment when accessing or processing Sentinel 5P collection using openEO. 

 Therefore, a callout is at the bottom of the Sentinel 5P data section to notify user to work with single band at once.