### PR TITLE
updated the date

### DIFF
--- a/Data/Others/Sentinel2_L2A_baseline.qmd
+++ b/Data/Others/Sentinel2_L2A_baseline.qmd
@@ -75,13 +75,13 @@ The Sentinel-2 Collection 1 (reprocessed data) featuring processing baseline 5.0
   <tbody>
     <tr>
       <td>Published (*)</td>
-      <td>From sensing 2017-11-12T00:00:00.000 to 2021-12-31T00:00:00.000</td>
-      <td>From sensing 2017-11-12T00:00:00.000 to 2021-12-31T00:00:00.000</td>
+      <td>From 22 June 2017 to 31 December 2021 included</td>
+      <td>From 22 June 2017 to 31 December 2021 included</td>
     </tr>
     <tr>
       <td>Next period in list</td>
-      <td>November 2017 then continuing in reverse chronological order of sensing time</td>
-      <td>November 2017 then continuing in reverse chronological order of sensing time</td>
+      <td>May 2017 then continuing in reverse chronological order of sensing time</td>
+      <td>May 2017 then continuing in reverse chronological order of sensing time</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Requested changes in baseline:

Updated availability by sensing time period 

Sentinel-2A

Sentinel-2B

Published

From 22 June 2017 to 31 December 2021 included

From 22 June 2017 to 31 December 2021 included

Next period in list

May 2017 then continuing in reverse chronological order of sensing time

May 2017 then continuing in reverse chronological order of sensing time