### PR TITLE
Fix broken openEO web editor link

### DIFF
--- a/APIs/openEO/openEO.qmd
+++ b/APIs/openEO/openEO.qmd
@@ -34,7 +34,8 @@ The key benefits of using openEO API can be summarized as follows:
 
 When using the openEO API, users can choose [JavaScript](JavaScript_Client/JavaScript.qmd), [Python](Python_Client/Python.qmd), or [R](R_Client/R.qmd) as their client library. This allows them to work with any backend and compare them based on capacity, cost, and result quality.
 
-Nevertheless, if you are unfamiliar with programming, you could start using the [web-based editor for openEO](#). It supports visual modelling of your algorithms and simplified JavaScript-based access to the openEO workflows and providers. An overview of the openEO web-editor is available in the [Applications](https://documentation.dataspace.copernicus.eu/Applications.html) section of this documentation.
+Nevertheless, if you are unfamiliar with programming, you could start using the [web-based editor for openEO](https://openeo.dataspace.copernicus.eu/).
+It supports visual modelling of your algorithms and simplified JavaScript-based access to the openEO workflows and providers. An overview of the openEO web-editor is available in the [Applications](https://documentation.dataspace.copernicus.eu/Applications.html) section of this documentation.
 
 ## Datacubes
 


### PR DESCRIPTION
on https://documentation.dataspace.copernicus.eu/APIs/openEO/openEO.html  link to openeo web editor does not work (it just links to `#`)

this PR fixes that using https://openeo.dataspace.copernicus.eu/    (so not federation yet)