### PR TITLE
openEO client credentials: document how to get "sub" identifier

### DIFF
--- a/APIs/openEO/authentication/client_credentials.qmd
+++ b/APIs/openEO/authentication/client_credentials.qmd
@@ -3,11 +3,13 @@ title: "Authentication With Client Credentials in openEO"
 ---
 
 
-OpenID Connect provides the so-called "client credentials flow",
+OpenID Connect provides the so-called "*client credentials flow*",
 which is a *non-interactive* flow, based on a static client id and a client secret,
 making it suitable for machine-to-machine authentication.
+Often, this is also referred to as "*service account*" authentication.
 
-The openEO Python client library has built-in support for the client credentials flow,
+The openEO Python client library has built-in support
+for service accounts and the client credentials flow,
 with the [`authenticate_oidc_client_credentials()` method](https://open-eo.github.io/openeo-python-client/auth.html#oidc-authentication-client-credentials-flow){target="_blank"}
 as follows:
 
@@ -20,7 +22,7 @@ connection.authenticate_oidc_client_credentials(
 
 
 ::: {.callout-warning}
-The use of client credentials in openEO is an experimental feature.
+The use of service accounts and client credentials in openEO is an experimental feature.
 It is not widely supported across openEO backends,
 and the setup procedure is not yet fully standardized or streamlined.
 :::
@@ -37,36 +39,36 @@ and the setup procedure is not yet fully standardized or streamlined.
     Instead, read the client secret from a secure location
     (e.g. a private file outside the reach of the version control repositories),
     or leverage environment variables (e.g as directly [supported by the openEO Python client library](https://open-eo.github.io/openeo-python-client/auth.html#oidc-client-credentials-using-environment-variables){target="_blank"}).
--   The client credentials only identify an OAuth client, not a personal user account.
+-   The client credentials only identify an OAuth *client* or *service account*,
+    not a personal *user* account.
 
     -   This means that openEO resources such as openEO batch jobs, their results, UDP's, etc
         from one identity are not available to the other.
-        For example, batch jobs originally created with client credentials
+        For example, batch jobs originally created with a service account
         cannot be listed when using a personal account.
     -   Likewise, the balances of processing credits are separate.
-        However, it is possible to link the balance of the client credentials account to a personal account.
+        However, it is possible to link the balance of the service account to a personal account.
         To enable this, contact support and provide the client ID and user ID.
 
 -   The client credentials flow is not supported on the
     [Copernicus Data Space Ecosystem openEO web editor](https://openeo.dataspace.copernicus.eu/).
     As mentioned above,
     this practically means that it can not be used to track the progress and
-    status of batch jobs created with client credentials.
+    status of batch jobs created with a service account.
     However, it is still possible to approximate the batch job overview of the web editor
     with a Jupyter Notebook using the openEO Python client library.
 
 
+## How To Create Service Accounts And Obtain Client Credentials
 
-## How to Obtain Client Credentials
-
-There are several options to generate/obtain client credentials,
+There are several options to create or request a service account with client credentials.
 Which one to choose depends on the particular use case.
 For simple, personal use cases and initial testing,
 the self-service feature of the Sentinel Hub Dashboard is the easiest option.
 For larger use cases or projects that should not be tied to a single developer,
 it is recommended to request a client through the CDSE Account management service.
 
-### Obtain Client Credentials with Sentinel Hub Dashboard
+### Obtain Client Credentials With The Sentinel Hub Dashboard
 
 The Sentinel Hub service in the Copernicus Data Space Ecosystem
 has a [dashboard web app](https://shapps.dataspace.copernicus.eu/dashboard),
@@ -78,18 +80,18 @@ The client id and client secret obtained with this dashboard can also be used
 for the client credentials flow with the openEO service of Copernicus Data Space Ecosystem.
 
 
-###  Obtain Client Credentials with the CDSE Account Management Service
+###  Request A Service Account From The CDSE Account Management Service
 
 The [account management service in the Copernicus Data Space Ecosystem](https://identity.dataspace.copernicus.eu/auth/realms/CDSE/account){target="_blank"}
-is managed by [CloudFerro](https://cloudferro.com/){target="_blank"}
-and the creation of OIDC/OAuth clients (e.g. with the client credentials grant)
-can be requested through their JIRA ticketing system.
+(managed by [CloudFerro](https://cloudferro.com/){target="_blank"})
+supports the creation of OIDC/OAuth clients (e.g. service accounts based on the client credentials grant)
+through CloudFerro's JIRA ticketing system.
 
 
 ::: {.callout-warning}
 
 Creating a such a ticket requires a valid user account on the CloudFerro JIRA system,
-which is currently out of scope of this documentation.
+which is currently not covered by this documentation.
 Contact the [CDSE support team](https://helpcenter.dataspace.copernicus.eu/)
 for more information.
 

--- a/APIs/openEO/authentication/client_credentials.qmd
+++ b/APIs/openEO/authentication/client_credentials.qmd
@@ -1,10 +1,12 @@
 ---
 title: "Authentication With Client Credentials in openEO"
+execute:
+  enabled: false
 ---
 
 
 OpenID Connect provides the so-called "*client credentials flow*",
-which is a *non-interactive* flow, based on a static client id and a client secret,
+which is a *non-interactive* flow, based on a static client ID and a client secret,
 making it suitable for machine-to-machine authentication.
 Often, this is also referred to as "*service account*" authentication.
 
@@ -76,7 +78,7 @@ which includes a self-service feature to register personal OAuth clients.
 Find more detailed instructions in the
 [documentation on Sentinel Hub Authentication](../../SentinelHub/Overview/Authentication.qmd#registering-oauth-client){target="_blank"}.
 
-The client id and client secret obtained with this dashboard can also be used
+The client ID and client secret obtained with this dashboard can also be used
 for the client credentials flow with the openEO service of Copernicus Data Space Ecosystem.
 
 
@@ -148,3 +150,48 @@ for a given use case or project:
 
 4. After submitting this JIRA ticket:
    allow the CloudFerro team some time to review and address the client creation request.
+
+
+## Obtain The OIDC Identifier Of A Service Account
+
+The setup of the service account with client credentials, as discussed above,
+is a matter between the user creating (or requesting) the service account
+and the CDSE Account Management Service.
+Other services like an openEO backend have no direct involvement in this process
+nor insights into how service accounts are linked
+to personal accounts or higher level projects.
+
+When you are in the process of linking a service account to another entity,
+for example for openEO credit accounting purposes,
+you will be required to provide the "OIDC subject identifier" (the OIDC "sub" claim)
+associated with the service account.
+Note that this is different from the client ID of the service account.
+
+This "sub" claim can be obtained for example with the following Python code snippet,
+using the openEO Python client library:
+
+```python
+import getpass
+import openeo
+
+connection = openeo.connect(url="openeo.dataspace.copernicus.eu")
+
+client_id = getpass.getpass("Client ID: ")
+client_secret = getpass.getpass("Client secret: ")
+connection.authenticate_oidc_client_credentials(
+    client_id=client_id,
+    client_secret=client_secret,
+)
+
+client_sub_id = con.describe_account()["user_id"]
+print(client_sub_id)
+```
+
+::: {.callout-important}
+
+To avoid the bad practice of hardcoding the client secret in scripts or notebooks,
+this snippet uses the `getpass` module from Python's standard library
+to interactively and securely prompt the user for the client ID and secret,
+in a way that is compatible with both standard CLI usage and Jupyter notebook contexts.
+
+:::


### PR DESCRIPTION
for https://github.com/eu-cdse/openeo-cdse-infra/issues/235:
- use term "service account" more prominently
- document how to get "sub" id of a service account (related to MKTP-471 and https://github.com/eu-cdse/documentation/issues/630)