### PR TITLE
group catalog and download pages

### DIFF
--- a/APIs.qmd
+++ b/APIs.qmd
@@ -24,10 +24,17 @@ listing:
 ---
 
 
-This section gives an overview on the APIs provided by Copernicus Data Space Ecosystem.
+This section gives an overview on the APIs provided by Copernicus Data Space Ecosystem. This is a set of HTTP endpoints
+and libraries in Python that allow developers and data scientists to interact with the Copernicus Data Space Ecosystem from
+their own applications.
 
 
 ## Catalog APIs
+
+The Copernicus programme generates a vast amount of data, which at its lowest level is available in the form of (raster) files.
+These files are referred to as 'products' or 'items' in the earth observation world. Products are grouped in 'collections'
+of homogeneous data streams (e.g. Sentinel-2 Level-1C, Sentinel-2 Level-2A, etc.). Collections are further grouped in 'catalogs'.
+
 There are various interfaces providing capability to search the catalog, to serve various users'
 needs and to ensure continuity over the existing Copernicus Hubs. All interfaces are connected to
 the same database to guarantee consistency.
@@ -46,7 +53,11 @@ The [release notes document](APIs/Others/ReleaseNotes.qmd) provides you with a c
 
 ## Streamlined data access
 
-The Streamlined Data Access APIs (SDA) enables users to access and retrieve Earth observation (EO) data from the Copernicus Data Space Ecosystem catalogue. These APIs also provide you with a set of tools and services to support data processing and analysiss. 
+The Streamlined Data Access APIs (SDA) provide the most intuitive option to access and retrieve Earth observation (EO) data from the 
+Copernicus Data Space Ecosystem. These APIs provide access to the most commonly used data in a unified manner, reducing
+the need to learn the specifics of each collection. 
+
+By including processing capabilities, they avoid having to download and manage huge volumes of data locally.
 
 ::: {#StreamlinedDataAccess}
 :::

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -82,29 +82,30 @@ website:
       - section: "APIs"
         href: APIs.qmd
         contents:
-          - href: APIs/Token.qmd
-            text: Access Token
-          - section: "OData"
-            href: APIs/OData.qmd
+          - section: "Product search and download"
             contents:
-            - href: "APIs/Subscriptions.qmd"
-              text: Subscriptions
-            - href: "APIs/Sentinel-1 SLC Burst.qmd"
-              text: Sentinel-1 SLC Bursts
-          - href: APIs/OpenSearch.qmd
-            text: OpenSearch
-          - href: APIs/STAC.qmd
-            text: STAC product catalogue
+              - href: APIs/Token.qmd
+                text: Access Token
+              - section: "OData"
+                href: APIs/OData.qmd
+                contents:
+                - href: "APIs/Subscriptions.qmd"
+                  text: Catalog subscriptions
+                - href: "APIs/Sentinel-1 SLC Burst.qmd"
+                  text: Sentinel-1 SLC Bursts
+              - href: APIs/OpenSearch.qmd
+                text: OpenSearch
+              - href: APIs/STAC.qmd
+                text: STAC product catalogue
+              - href: APIs/S3.qmd
+                text: S3 Access
+              - href: APIs/TCP.qmd
+                text: TCP stack configuration
+              - href: APIs/Traceability.qmd
+                text: Traceability API
           - href: APIs/Subscriptions.qmd
             text: Subscriptions
-          - href: APIs/S3.qmd
-            text: S3 Access
-          - href: APIs/TCP.qmd
-            text: TCP stack configuration
-          - href: APIs/On-Demand Production API.qmd
-            text: On-Demand Production API
-          - href: APIs/Traceability.qmd
-            text: Traceability API
+
           - section: "openEO"
             href: APIs/openEO/openEO.qmd
             contents:
@@ -304,6 +305,8 @@ website:
                     text: Examples for OGC
               - href: "APIs/SentinelHub/ApiReference.qmd"
                 text: "API Reference"
+          - href: APIs/On-Demand Production API.qmd
+            text: On-Demand Production API
       - section: "Applications"
         href: Applications.qmd
         contents:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -103,9 +103,6 @@ website:
                 text: TCP stack configuration
               - href: APIs/Traceability.qmd
                 text: Traceability API
-          - href: APIs/Subscriptions.qmd
-            text: Subscriptions
-
           - section: "openEO"
             href: APIs/openEO/openEO.qmd
             contents:


### PR DESCRIPTION
This PR is a first to address the complexity of our technical documentation.

It proposes a better organization of the pages, aimed at guiding users to the right information depending on their use case.
More specifically 8 pages that all belonged to the use case of product search and download are now effectively grouped as such.

This provides the extra context to the user that for instance 'tcp stack configuration' applies to the theme of search and download, and for instance not to the SDA APIs. 

This also makes the SDA option more prominent, in line with the requirement to guide more users to these api's and thus more effective usage of EO data. 