### PR TITLE
expose openeofed on main openEO page

### DIFF
--- a/APIs/openEO/Collections.qmd
+++ b/APIs/openEO/Collections.qmd
@@ -18,7 +18,7 @@ The following are the list of data collections available currently in the Copern
 #| echo: false
 #| output: false
 import openeo
-connection = openeo.connect("openeo.dataspace.copernicus.eu")
+connection = openeo.connect("openeofed.dataspace.copernicus.eu")
 
 ```
 ```{python}

--- a/APIs/openEO/JavaScript_Client/JavaScript.qmd
+++ b/APIs/openEO/JavaScript_Client/JavaScript.qmd
@@ -58,12 +58,13 @@ If you have trouble installing the client, feel free to [create a ticket](https:
 
 ## Exploring a back-end
 
-For this tutorial we will use the openEO instance of Copernicus Data Space Ecosystem, which is available at `https://openeo.dataspace.copernicus.eu`.
+For this tutorial we will use the [openEO federation backend](../federation/openeo_federation.md) of Copernicus Data Space Ecosystem, which is available at `https://openeofed.dataspace.copernicus.eu`.
+Use `https://openeo.dataspace.copernicus.eu` to limit the connection to the core CDSE offering.
 
 First we need to establish a connection to the back-end.
 
 ```js
-var con = await OpenEO.connect("https://openeo.dataspace.copernicus.eu");
+var con = await OpenEO.connect("https://openeofed.dataspace.copernicus.eu");
 
 ```
 
@@ -73,7 +74,7 @@ The JavaScript client uses [Promises (async/await)](https://medium.com/jspoint/j
 
 Promises:
 ```js
-OpenEO.connect("https://openeo.dataspace.copernicus.eu").then(function(con) {
+OpenEO.connect("https://openeofed.dataspace.copernicus.eu").then(function(con) {
   // Success
 }).catch(function(error) {
   // Error
@@ -84,7 +85,7 @@ async/await:
 
 ```js
 try {
-  var con = await OpenEO.connect("https://openeo.dataspace.copernicus.eu");
+  var con = await OpenEO.connect("https://openeofed.dataspace.copernicus.eu");
   // Success
 } catch (error) {
   // Error
@@ -133,10 +134,10 @@ response.collections.forEach(collection => {
 ```
 
 To get detailed information about a single collection, you can pass any of the collection IDs requested earlier to `describeCollection` and get a full object of [STAC compliant Collection metadata](https://github.com/radiantearth/stac-spec/tree/v1.0.0/collection-spec/collection-spec.md){target="_blank"} back.
-In this example we request information about the Sentinel-2 Level 1C data from Google:
+In this example we request information about the Sentinel-2 Level 1C data:
 
 ```js
-console.log(await con.describeCollection("COPERNICUS/S2"));
+console.log(await con.describeCollection("SENTINEL2_L1C"));
 ```
 
 To get the full set of metadata you should always use `describeCollection`.
@@ -359,7 +360,7 @@ const { OpenEO, Formula } = require('@openeo/js-client');
 
 async function example() {
   // Connect to the back-end
-  var con = await OpenEO.connect("https://openeo.dataspace.copernicus.eu");
+  var con = await OpenEO.connect("https://openeofed.dataspace.copernicus.eu");
   // Authenticate 
   await con.authenticateOIDC();
   // Create a process builder

--- a/APIs/openEO/Python_Client/Python.qmd
+++ b/APIs/openEO/Python_Client/Python.qmd
@@ -48,14 +48,15 @@ for more details, alternative installation procedures or troubleshooting tips.
 
 ## Exploring a back-end
 
-For this tutorial we will use the openEO back-end of Copernicus Data Space Ecosystem, 
-which is available at `https://openeo.dataspace.copernicus.eu`.
+For this tutorial we will use the openEO federation back-end of Copernicus Data Space Ecosystem, 
+which is available at `https://openeofed.dataspace.copernicus.eu`. This backend also provides access to partner resources. 
+Use `https://openeo.dataspace.copernicus.eu` to limit your access to the core CSDE offering.
 We establish a connection to this back-end as follows:
 
 ```python
 import openeo
 
-connection = openeo.connect("openeo.dataspace.copernicus.eu")
+connection = openeo.connect("openeofed.dataspace.copernicus.eu")
 ```
 
 
@@ -279,7 +280,7 @@ A common task in earth observation is to apply a formula to a number of spectral
 import openeo
 
 # First, we connect to the back-end and authenticate. 
-con = openeo.connect("openeo.dataspace.copernicus.eu")
+con = openeo.connect("openeofed.dataspace.copernicus.eu")
 con.authenticate_oidc()
 
 # Now that we are connected, we can initialize our datacube object with the area of interest 

--- a/APIs/openEO/R_Client/R.qmd
+++ b/APIs/openEO/R_Client/R.qmd
@@ -46,12 +46,13 @@ With the successful completion of the installation, import it to use openEO-comp
 ## Exploring a back-end
 
 
-First, establish a connection to the Copernicus Data Space Ecosystem backend. The endpoint is `https://openeo.dataspace.copernicus.eu`.
+First, establish a connection to the Copernicus Data Space Ecosystem [openEO federation backend](../federation/openeo_federation.md). The endpoint is `https://openeofed.dataspace.copernicus.eu`.
+Use `https://openeo.dataspace.copernicus.eu` to limit yourself to the core CDSE offering.
 
 ```r
 
 library(openeo)
-connection = connect(host = "https://openeo.dataspace.copernicus.eu")
+connection = connect(host = "https://openeofed.dataspace.copernicus.eu")
 
 ```
 
@@ -252,7 +253,7 @@ The code example below includes inline comments explaining each step of the proc
 library(openeo)
 
 # connect to the backend and authenticate
-connection = connect(host = "https://openeo.dataspace.copernicus.eu")
+connection = connect(host = "https://openeofed.dataspace.copernicus.eu")
 login()
 # get the process collection to use the predefined processes of the back-end
 p = processes()

--- a/APIs/openEO/federation/openeo_federation.md
+++ b/APIs/openEO/federation/openeo_federation.md
@@ -7,10 +7,6 @@ This function, referred to as the openEO federation, is available through the fo
 
 [https://openeofed.dataspace.copernicus.eu](https://openeofed.dataspace.copernicus.eu)
 
-Currently, we are actively encouraging early adopters and projects with specific needs to try this new capability.
-While it has already been extensively tested by users of other projects, the configuration in the CDSE is still new.
-As a result, we are offering this feature as a 'beta' service at first.
-This approach allows us to still adjust the configuration based on your feedback.
 
 When using the federated endpoint, you will be asked to give your consent to share basic user information with the other providers of the federation.
 Additionally, you will be requested to accept the new terms and conditions. You can withdraw your consent at any time through your CDSE account dashboard.

--- a/APIs/openEO/openEO.qmd
+++ b/APIs/openEO/openEO.qmd
@@ -12,15 +12,31 @@ jupyter: python3
 
 <div style="display: flex; align-items: center;"><p style="flex: 1; text-align: justify;"><a href="https://dataspace.copernicus.eu/analyse/openeo">openEO</a> represents an innovative community standard that revolutionizes geospatial data processing and analysis. This groundbreaking framework provides a novel approach to accessing, processing, and analyzing diverse Earth observation data. By adopting openEO, developers, researchers, and data scientists gain access to a unified and interoperable platform, empowering them to harness distributed computing environments and leverage cloud-based resources for addressing complex geospatial challenges.</p><a href="hhttps://dataspace.copernicus.eu/analyse/openeo" target="_blank" style="margin-left: 40px;"><img src="_images/openEO_logo.png" alt="Logo" style="height: 50%; max-height: 100px;"></a></div>
 
-
-
-With openEO's collaborative nature, users can seamlessly share code, workflows, and data processing methods across platforms and tools, fostering collaboration and advancing the accessibility, scalability, and reproducibility of Earth observation data. Additionally, openEO provides intuitive programming libraries that enable easy analysis of diverse Earth observation datasets. These libraries facilitate efficient access and processing of large-scale data across multiple infrastructures, supporting various applications, including exploratory research, detailed mapping, and information extraction from Earth observation. Moreover, this streamlined approach enhances the development process, enabling the utilization of Earth observation data for a wide range of applications and services.
+With openEO's collaborative nature, users can seamlessly share code, workflows, and data processing methods across platforms and tools,
+fostering collaboration and advancing the accessibility, scalability, and reproducibility of Earth observation data. 
+Additionally, openEO provides intuitive programming libraries that enable easy analysis of diverse Earth observation datasets. 
+These libraries facilitate efficient access and processing of large-scale data across multiple infrastructures, supporting 
+various applications, including exploratory research, detailed mapping, and information extraction from Earth observation. 
+Moreover, this streamlined approach enhances the development process, enabling the utilization of Earth observation data 
+for a wide range of applications and services.
 
 The endpoint for the public service is 100% open source and compatible with Pangeo technology. Read more about it [here](openeo_deployment.md).
 
-Endpoint: [https://openeo.dataspace.copernicus.eu/](https://openeo.dataspace.copernicus.eu/){target="_blank"}
+Endpoint: [https://openeofed.dataspace.copernicus.eu/](https://openeofed.dataspace.copernicus.eu/){target="_blank"}
 
 Concrete examples of what you can do with openEO can be found in the [notebooks section](/Usecase.qmd) of this documentation.
+
+::: {.callout-tip}
+## Automatic access to the EU ecosystem
+
+The openEO service is unique in providing access to the core datasets as well as including partner platforms in the ecosystem.
+
+Read more about the [CDSE openEO federation](./federation/openeo_federation.md) to understand how this works, and which
+partners are involved.
+
+To avoid automatic use of partner resources, you can use a separate endpoint: 
+[https://openeo.dataspace.copernicus.eu/](https://openeo.dataspace.copernicus.eu/){target="_blank"}
+:::
 
 ## Added value of openEO API
 
@@ -34,7 +50,7 @@ The key benefits of using openEO API can be summarized as follows:
 
 When using the openEO API, users can choose [JavaScript](JavaScript_Client/JavaScript.qmd), [Python](Python_Client/Python.qmd), or [R](R_Client/R.qmd) as their client library. This allows them to work with any backend and compare them based on capacity, cost, and result quality.
 
-Nevertheless, if you are unfamiliar with programming, you could start using the [web-based editor for openEO](https://openeo.dataspace.copernicus.eu/).
+Nevertheless, if you are unfamiliar with programming, you could start using the [web-based editor for openEO](https://openeofed.dataspace.copernicus.eu/).
 It supports visual modelling of your algorithms and simplified JavaScript-based access to the openEO workflows and providers. An overview of the openEO web-editor is available in the [Applications](https://documentation.dataspace.copernicus.eu/Applications.html) section of this documentation.
 
 ## Datacubes
@@ -46,7 +62,7 @@ In openEO, a datacube is a fundamental concept and a key component of the platfo
 #| echo: false
 #| output: false
 import openeo
-connection = openeo.connect("openeo.dataspace.copernicus.eu")
+connection = openeo.connect("openeofed.dataspace.copernicus.eu")
 
 ```
 

--- a/notebook_filter.py
+++ b/notebook_filter.py
@@ -7,7 +7,7 @@ nb = nbformat.reads(sys.stdin.read(), as_version=4)
 # prepend a comment to the source of each cell
 for index, cell in enumerate(nb.cells):
     if cell.cell_type == 'code':
-        cell.source = cell.source.replace("openeo.cloud","openeo.dataspace.copernicus.eu")
+        cell.source = cell.source.replace("openeo.cloud","openeofed.dataspace.copernicus.eu")
 
 # write notebook to stdout
 nbformat.write(nb, sys.stdout)


### PR DESCRIPTION
After a period of public testing and making improvements, we can now push the 'openeofed' endpoint more prominently.

The idea is to consistently refer to openeofed.dataspace.copernicus.eu everywhere, avoiding that users get confused with seeing different endpoints.

