### PR TITLE
Fix byoc collections configuration section

### DIFF
--- a/APIs/SentinelHub/Byoc.qmd
+++ b/APIs/SentinelHub/Byoc.qmd
@@ -217,9 +217,7 @@ A python script to set a bucket policy can be downloaded
 
 When creating a collection:
 
--   you need to provide the S3 bucket where you data is; if you have
-    data in CreoDIAS, prefix the bucket name by your CreoDIAS Project ID
-    as follows: `PROJECT_ID:bucket_name` ,
+-   you need to provide the name of the S3 bucket where your data is stored,
 -   you can define bands, but only using BYOC API,
 -   you can provide the no data value using Dashboard or BYOC API.
 


### PR DESCRIPTION
It is no longer necessary to define the bucket name as `PROJECT_ID:bucket_name`.