### PR TITLE
Update VHR streaming FAQ for new CCM VHR template configuration

### DIFF
--- a/FAQ.qmd
+++ b/FAQ.qmd
@@ -1172,8 +1172,20 @@ function evaluatePixel(samples) {
     If none of the above options work, please <a href="https://helpcenter.dataspace.copernicus.eu/hc/en-gb/requests/new" target="_blank">Submit a request</a> by providing the full name of the product(s) and which methods you tried/how they were resulted.
 </details>
 
+<details id="how-can-i-stream-vhr-data-in-copernicus-browser">
+    <summary onclick="handleQuestionClick('how-can-i-stream-vhr-data-in-copernicus-browser')">How can I stream VHR (Very High Resolution) data in Copernicus Browser?</summary>
+    <p>Download rights for VHR data from the Copernicus Contributing Missions (CCM) also include the right to stream this data. Because access to VHR data is restricted to eligible CCM User Categories, the CCM VHR template configuration is only visible to eligible users and is not included in the shared Configuration templates available to all users.</p>
+    <p>If you are eligible, you can create a configuration to visualize VHR data in Copernicus Browser:</p>
+    <ol>
+        <li><strong>Check eligibility:</strong> visit the <a href="https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/ccm-user-categories" target="_blank">Copernicus Contributing Missions User Categories</a> page to confirm your organisation is entitled to access the desired VHR dataset (e.g. VHR_IMAGE_2018, VHR_IMAGE_2021, VHR_IMAGE_2024). See <a href="#how-to-access-COP-DEM-10m">How to access COP-DEM 10m?</a> for the general CCM application process.</li>
+        <li><strong>Create a configuration:</strong> in the <a href="https://shapps.dataspace.copernicus.eu/dashboard/" target="_blank">Sentinel Hub Dashboard</a>, create a new configuration and select the "CCM VHR" template from the list of available template configurations — this template is only visible if you are eligible for the underlying VHR collection, and comes pre-configured with the correct layer and collection ID. Alternatively, you can add a new layer manually, selecting "Bring your own COG" as the source and setting the BYOC collection ID for the VHR dataset you are eligible for, e.g. <code>byoc-b016cf66-b68e-472d-8421-1fe9d384762f</code>. Contact the <a href="https://helpcenter.dataspace.copernicus.eu/hc/en-gb/requests/new" target="_blank">CDSE Support Team</a> if you do not know the collection ID for your dataset.</li>
+        <li><strong>Select your configuration in Browser:</strong> log into <a href="https://browser.dataspace.copernicus.eu/" target="_blank">Copernicus Browser</a>, select your configuration from the dropdown in <em>Configurations</em> under the <em>Visualize</em> tab, and your VHR layer will be available for selection under <em>Layers</em>.</li>
+    </ol>
+    <p>Note: because access to this data is restricted, do not share your configuration with users who are not eligible for the underlying VHR collection.</p>
+</details>
 
-## Integrate Data into GIS and Web applications 
+
+## Integrate Data into GIS and Web applications
 
 
 <details id="why-cant-i-see-ogc-layers-displayed-in-arcgis-online">


### PR DESCRIPTION
Sentinel Hub Dashboard now offers a pre-configured CCM VHR template in the configuration dropdown for eligible users, simplifying the manual BYOC setup previously required.

Relates to: https://hello.planet.com/code/solution-enablement/cdse-frontend/cdse/copernicus-browser/-/work_items/1114