### PR TITLE
Adjust data availability for CDSE S1 and S2 Mosaics

### DIFF
--- a/Data/collections.json
+++ b/Data/collections.json
@@ -540,14 +540,13 @@
                     {
                         "Mosaic": "IW",
                         "Spatial": "Non-polar landmasses, depends on availability of IW products",                        
-                        "Temporal": "Jan - Dec 2023 *",
-                        "S3 Path": "e.g., /eodata/Global-Mosaics/Sentinel-1/S1SAR_L3_IW_MCM/2023/01/01",
-                        "Note": "More mosaics coming soon."
+                        "Temporal": "Oct 2014 - Present",
+                        "S3 Path": "e.g., /eodata/Global-Mosaics/Sentinel-1/S1SAR_L3_IW_MCM/2023/01/01"
                     },
                     {
                         "Mosaic": "DH",
                         "Spatial": "Polar regions, depends on availability of HH + HV polarised products",                        
-                        "Temporal": "Jan - Dec 2023 *",
+                        "Temporal": "Oct 2014 - Present",
                         "S3 Path": "e.g., /eodata/Global-Mosaics/Sentinel-1/S1SAR_L3_DH_MCM/2023/01/01"
                     }
                 ]
@@ -1080,8 +1079,7 @@
                     {
                         "Archive_status": "Packed or Unpacked",
                         "Spatial" : "World",
-                        "Temporal": "(*) Jan 2022 - Present",
-                        "Note": "(*) More will be added"
+                        "Temporal": "Jul 2015 – Present"
                     }
                 ],
                 "eo:bands": [


### PR DESCRIPTION
The data availability for CDSE mosaics has never been updated. Now with the archive processing completed, we need to adjust the information in the docs (time range and notes). I deliberately chose "Month+Year - Present" to avoid monthly or quarterly updates.