### PR TITLE
update docs: beta note and date range

### DIFF
--- a/APIs/SentinelHub/Data/clms/land-cover-and-land-use-mapping/global-dynamic-land-cover/lcm_global_10m_yearly_v1.qmd
+++ b/APIs/SentinelHub/Data/clms/land-cover-and-land-use-mapping/global-dynamic-land-cover/lcm_global_10m_yearly_v1.qmd
@@ -5,7 +5,7 @@ collection: 828f6b20-8ffd-48f8-a1da-fefd271456db
 ## About
 [Official documentation](https://land.copernicus.eu/en/products/global-dynamic-land-cover/land-cover-2020-raster-10-m-global-annual)
 
-Provides at global level information on different types (classes) of physical coverage of the Earth's surface, e.g. tree cover, grasslands, croplands, permanent water bodies, wetlands at 10 m spatial resolution for the 2020 base year. The data are updated annually and will be available for the 2020-2026 years. This dataset builds upon initiatives like the 100 m Copernicus Global Land Cover layers (2015-2019) and offers enhanced spatial detail that facilitates more effective monitoring of global land cover changes, including deforestation, urbanization, and other environmental transformations. Please note: this version is still in beta status, as final validation is ongoing. 
+Provides at global level information on different types (classes) of physical coverage of the Earth's surface, e.g. tree cover, grasslands, croplands, permanent water bodies, wetlands at 10 m spatial resolution for the 2020 base year. This dataset builds upon initiatives like the 100 m Copernicus Global Land Cover layers (2015-2019) and offers enhanced spatial detail that facilitates more effective monitoring of global land cover changes, including deforestation, urbanization, and other environmental transformations.
 
 [View this dataset in Copernicus Browser](https://browser.dataspace.copernicus.eu/?zoom=10&lat=41.82019&lng=12.57866&themeId=DEFAULT-THEME&datasetId=828f6b20-8ffd-48f8-a1da-fefd271456db&clmsSelectedPath=Global%20Dynamic%20Land%20Cover&clmsSelectedCollection=828f6b20-8ffd-48f8-a1da-fefd271456db) (Click on 'Show latest date' after the page loads.)
 
@@ -19,7 +19,7 @@ Provides at global level information on different types (classes) of physical co
 
 ## Date range
 
-2020 - 2026
+2020
 
 ## Bands
 

--- a/APIs/SentinelHub/Data/clms/land-cover-and-land-use-mapping/global-dynamic-land-cover/tcd_pantropical_10m_yearly_v1.qmd
+++ b/APIs/SentinelHub/Data/clms/land-cover-and-land-use-mapping/global-dynamic-land-cover/tcd_pantropical_10m_yearly_v1.qmd
@@ -5,7 +5,7 @@ collection: 8bd33a42-dce4-4554-9a1f-1bb248b4183d
 ## About
 [Official documentation](https://land.copernicus.eu/en/products/global-dynamic-land-cover/tree-cover-density-2020-raster-10-m-pantropical-annual)
 
-Provides pantropical tree cover density as projective tree cover in percent per pixel at 10 m resolution for the 2020 base year. The data are updated annually and will be available for the 2020-2026 years. The product belongs to the Copernicus Global Land Cover and Tropical Forest Mapping and Monitoring Service (LCFM) and builds upon initiatives like the REDDCopernicus, EO4SD Forest Monitoring and pan-European Vegetated Land Cover Characteristics. It advances tropical forest monitoring capabilities, ensuring alignment with international sustainability initiatives and providing critical information for analysis and monitoring of deforestation and forest degradation. Please note: this version is still in beta status, as final validation is ongoing.
+Provides pantropical tree cover density as projective tree cover in percent per pixel at 10 m resolution for the 2020 base year. The product belongs to the Copernicus Global Land Cover and Tropical Forest Mapping and Monitoring Service (LCFM) and builds upon initiatives like the REDDCopernicus, EO4SD Forest Monitoring and pan-European Vegetated Land Cover Characteristics. It advances tropical forest monitoring capabilities, ensuring alignment with international sustainability initiatives and providing critical information for analysis and monitoring of deforestation and forest degradation.
 
 [View this dataset in Copernicus Browser](https://browser.dataspace.copernicus.eu/?zoom=10&lat=19.35456&lng=-99.13651&themeId=DEFAULT-THEME&datasetId=8bd33a42-dce4-4554-9a1f-1bb248b4183d&clmsSelectedPath=Global%20Dynamic%20Land%20Cover&clmsSelectedCollection=8bd33a42-dce4-4554-9a1f-1bb248b4183d) (Click on 'Show latest date' after the page loads.)
 
@@ -19,7 +19,7 @@ Provides pantropical tree cover density as projective tree cover in percent per 
 
 ## Date range
 
-2020 - 2026
+2020
 
 ## Bands
 

--- a/APIs/SentinelHub/Data/clms/land-cover-and-use-in-priority-areas/urban-atlas/building-height/clms_ua_building-height_europe_10m_3yearly_v1.qmd
+++ b/APIs/SentinelHub/Data/clms/land-cover-and-use-in-priority-areas/urban-atlas/building-height/clms_ua_building-height_europe_10m_3yearly_v1.qmd
@@ -19,7 +19,7 @@ Urban Atlas Building Block Height 2021 is a 10 m high resolution raster layer co
 
 ## Date range
 
-2021 - 2021
+2021
 
 ## Bands
 


### PR DESCRIPTION
Updates docs according to: https://gitext.sinergise.com/sentinel-projects/cdse/cdse-team/-/issues/1092
- date range is updated from 2020-2026 to 2020
- beta note gets removed

Additionally updates Urban Atlas building-height page: the date range now appears as `2021 `instead of `2021 - 2021`